### PR TITLE
Adding zoom_to_fill photo display type

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ However, there are some additional guidelines that should be used for AI commits
 | `SMPL_FRM_TIMEZONE`                     | "America/Los_Angeles"              | TZ Identified from [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)                              |
 | `SMPL_FRM_IMAGE_CACHE_TIMEOUT`          | "86400"                            | Seconds until the image should be removed from the cache                                                                  |
 | `SMPL_FRM_CLEAR_CACHE_ON_BOOT`          | False                              | Clears Cache on Service Boot                                                                                              |
-| `SMPL_FRM_IMAGE_FILL_MODE`              | "blur"                             | How to fill aspect ratio gaps: `border` (replicate edges) or `blur` (blurred background)                                  |
+| `SMPL_FRM_IMAGE_FILL_MODE`              | "blur"                             | How to fill aspect ratio gaps: `border` (replicate edges), `blur` (blurred background), or `zoom_to_fill` (zoom to fill) |
 | `SMPL_FRM_PLUGINS_SPOTIFY_ENABLED`      | False                              | Enables Spotify Now Playing Plugin                                                                                        |
 | `SMPL_FRM_PLUGINS_SPOTIFY_CLIENT_ID`    | None                               | See: https://spotipy.readthedocs.io/en/latest/#getting-started                                                            |
 | `SMPL_FRM_PLUGINS_SPOTIFY_CLIENT_SECRET` | None                               | See ^ - Ensure your Redirect URI matches  Http://`SMPL_FRM_HOST`:`SMPL_FRM_EXTERNAL_PORT`/api/v1/plugins/spotify/callback |

--- a/src/smplfrm/smplfrm/services/cache_service.py
+++ b/src/smplfrm/smplfrm/services/cache_service.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
+from smplfrm.settings import SMPL_FRM_IMAGE_FILL_MODE
 
 
 class CacheService:
@@ -67,4 +68,4 @@ class CacheService:
         Returns:
             Formatted cache key string
         """
-        return f"{external_id}:{height}:{width}"
+        return f"{external_id}:{SMPL_FRM_IMAGE_FILL_MODE}:{height}:{width}"

--- a/src/smplfrm/smplfrm/services/image_manipulation_service.py
+++ b/src/smplfrm/smplfrm/services/image_manipulation_service.py
@@ -76,7 +76,12 @@ class ImageManipulationService:
             resized_img = self._scale_with_blur_background(
                 img, window_width, window_height
             )
+        elif SMPL_FRM_IMAGE_FILL_MODE == "zoom_to_fill":
+            resized_img = self._scale_with_zoom_to_fill(
+                img, window_width, window_height
+            )
         else:
+            logger.warning("Invalid SMPL_FRM_IMAGE_FILL_MODE, using border fill")
             resized_img = self._scale_with_border(img, window_width, window_height)
 
         logger.info(f"Resized Image: {image.name}")
@@ -126,6 +131,51 @@ class ImageManipulationService:
         ] = resized_main
 
         return background
+
+    def _scale_with_zoom_to_fill(
+        self, img: np.ndarray, window_width: int, window_height: int
+    ) -> np.ndarray:
+        """Scale image by zooming and cropping to fill viewport.
+
+        Args:
+            img: Source image
+            window_width: Target width
+            window_height: Target height
+
+        Returns:
+            Cropped and scaled image filling entire viewport
+        """
+        image_h, image_w = img.shape[:2]
+
+        if window_height == 0 or window_width == 0:
+            return img
+
+        # Calculate aspect ratios
+        target_aspect = window_width / window_height
+        image_aspect = image_w / image_h
+
+        # Zoom to fill (crop to fit)
+        if image_aspect > target_aspect:
+            # Image is wider, scale by height and crop width
+            new_height = window_height
+            new_width = int(window_height * image_aspect)
+        else:
+            # Image is taller, scale by width and crop height
+            new_width = window_width
+            new_height = int(window_width / image_aspect)
+
+        # Resize image
+        resized = cv2.resize(img, (new_width, new_height), interpolation=cv2.INTER_AREA)
+
+        # Center crop to target dimensions
+        y_offset = (new_height - window_height) // 2
+        x_offset = (new_width - window_width) // 2
+
+        cropped = resized[
+            y_offset : y_offset + window_height, x_offset : x_offset + window_width
+        ]
+
+        return cropped
 
     def _scale_with_border(
         self, img: np.ndarray, window_width: int, window_height: int

--- a/src/smplfrm/smplfrm/tests/services/test_cache_service.py
+++ b/src/smplfrm/smplfrm/tests/services/test_cache_service.py
@@ -48,10 +48,11 @@ class TestImageService(TestCase):
 
     def test_image_cache_key(self):
         ext_id = "foo"
+        display_type = "blur"
         height = "10"
         width = "20"
 
         self.assertEqual(
-            f"{ext_id}:{height}:{width}",
+            f"{ext_id}:{display_type}:{height}:{width}",
             self.service.get_image_cache_key(ext_id, height, width),
         )

--- a/src/smplfrm/smplfrm/tests/services/test_image_manipulation_service.py
+++ b/src/smplfrm/smplfrm/tests/services/test_image_manipulation_service.py
@@ -203,3 +203,91 @@ class TestImageManipulationService(TestCase):
         # Verify it has 3 color channels (BGR)
         self.assertEqual(len(img.shape), 3)
         self.assertEqual(img.shape[2], 3)
+
+    @override_settings(SMPL_FRM_IMAGE_FILL_MODE="zoom_to_fill")
+    def test_scale_horizontal_image_with_zoom_to_fill(self):
+        """Test scaling horizontal image with Ken Burns effect."""
+        window_h = 100
+        window_w = 100
+
+        image = self.image_service.list(
+            file_name="david-becker-F7SBonu15d8-unsplash.jpg"
+        )[0]
+
+        displayed_image = self.image_manipulation_service.display(
+            image, window_height=window_h, window_width=window_w
+        )
+
+        img = cv2.imdecode(displayed_image, -1)
+        size = img.shape[:2]
+        image_h = size[0]
+        image_w = size[1]
+
+        # Ken Burns fills entire viewport
+        self.assertEqual(window_w, image_w)
+        self.assertEqual(window_h, image_h)
+
+    @override_settings(SMPL_FRM_IMAGE_FILL_MODE="zoom_to_fill")
+    def test_scale_vertical_image_with_zoom_to_fill(self):
+        """Test scaling vertical image with Ken Burns effect."""
+        window_h = 100
+        window_w = 100
+
+        image = self.image_service.list(
+            file_name="kelly-sikkema-PqqQDpS6H6A-unsplash.jpg"
+        )[0]
+
+        displayed_image = self.image_manipulation_service.display(
+            image, window_height=window_h, window_width=window_w
+        )
+
+        img = cv2.imdecode(displayed_image, -1)
+        size = img.shape[:2]
+        image_h = size[0]
+        image_w = size[1]
+
+        # Ken Burns fills entire viewport
+        self.assertEqual(window_h, image_h)
+        self.assertEqual(window_w, image_w)
+
+    @override_settings(SMPL_FRM_IMAGE_FILL_MODE="zoom_to_fill")
+    def test_scale_panoramic_image_with_zoom_to_fill(self):
+        """Test scaling panoramic image with Ken Burns effect."""
+        window_h = 433
+        window_w = 952
+
+        image = self.image_service.list(
+            file_name="bernd-dittrich-73scJ3UOdHM-unsplash.jpg"
+        )[0]
+
+        displayed_image = self.image_manipulation_service.display(
+            image, window_height=window_h, window_width=window_w
+        )
+
+        img = cv2.imdecode(displayed_image, -1)
+        size = img.shape[:2]
+        image_h = size[0]
+        image_w = size[1]
+
+        # Ken Burns fills entire viewport
+        self.assertEqual(window_w, image_w)
+        self.assertEqual(window_h, image_h)
+
+    @override_settings(SMPL_FRM_IMAGE_FILL_MODE="zoom_to_fill")
+    def test_zoom_to_fill_crops_to_fill(self):
+        """Test that Ken Burns mode crops image to fill viewport without gaps."""
+        window_h = 200
+        window_w = 300
+
+        image = self.image_service.list()[0]
+        displayed_image = self.image_manipulation_service.display(
+            image, window_height=window_h, window_width=window_w
+        )
+
+        img = cv2.imdecode(displayed_image, -1)
+
+        # Verify exact dimensions (no borders or gaps)
+        self.assertEqual(img.shape[0], window_h)
+        self.assertEqual(img.shape[1], window_w)
+        # Verify it's a valid color image
+        self.assertEqual(img.shape[2], 3)


### PR DESCRIPTION
This adds the `zoom_to_fill` image display type. This display type aggressively crops a photo to fit the viewport. Its not recommended for photo libraries with a wide variety of aspect ratios. 

This commit also updates the cache key to include the display type so that existing cached images using a different display type will not be used. Those images will naturally be evicted from the cache. 

Fixes #78 