### PR TITLE
Add timezone, fill mode, and date-from-path settings (#136)

### DIFF
--- a/src/smplfrm/smplfrm/static/main.js
+++ b/src/smplfrm/smplfrm/static/main.js
@@ -290,6 +290,9 @@ async function loadConfig() {
         document.getElementById('setting-zoom').checked = config.image_zoom_effect;
         document.getElementById('setting-transition-type').value = config.image_transition_type;
         document.getElementById('setting-cache-timeout').value = config.image_cache_timeout;
+        document.getElementById('setting-timezone').value = config.timezone;
+        document.getElementById('setting-fill-mode').value = config.image_fill_mode;
+        document.getElementById('setting-force-date-path').checked = config.force_date_from_path;
     } catch (error) {
         console.error('Error loading config:', error);
     }
@@ -309,7 +312,10 @@ async function saveConfig() {
         image_transition_interval: parseInt(document.getElementById('setting-transition').value),
         image_zoom_effect: document.getElementById('setting-zoom').checked,
         image_transition_type: document.getElementById('setting-transition-type').value,
-        image_cache_timeout: parseInt(document.getElementById('setting-cache-timeout').value)
+        image_cache_timeout: parseInt(document.getElementById('setting-cache-timeout').value),
+        timezone: document.getElementById('setting-timezone').value,
+        image_fill_mode: document.getElementById('setting-fill-mode').value,
+        force_date_from_path: document.getElementById('setting-force-date-path').checked
     };
     
     try {

--- a/src/smplfrm/smplfrm/static/styles.css
+++ b/src/smplfrm/smplfrm/static/styles.css
@@ -484,13 +484,16 @@ input:checked + .slider:before {
 }
 
 .select-input {
-    width: 100%;
     padding: 8px;
     background: #222;
     border: 1px solid #444;
     border-radius: 6px;
     color: #fff;
     font-size: 14px;
+}
+
+.timezone-input {
+    max-width: 280px;
 }
 
 .modal-actions {

--- a/src/smplfrm/smplfrm/templates/index.html
+++ b/src/smplfrm/smplfrm/templates/index.html
@@ -86,11 +86,27 @@
                     </label>
                 </div>
                 <div class="setting-item">
+                    <label for="setting-force-date-path" title="Use the file path (YYYY/MM) to determine the photo date instead of EXIF data">Photo Date From File Path</label>
+                    <label class="toggle-switch">
+                        <input type="checkbox" id="setting-force-date-path">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+                <div class="setting-item">
                     <label for="setting-clock">Show Date And Time</label>
                     <label class="toggle-switch">
                         <input type="checkbox" id="setting-clock">
                         <span class="slider"></span>
                     </label>
+                </div>
+                <div class="setting-item">
+                    <label for="setting-timezone">Timezone</label>
+                    <input type="text" id="setting-timezone" list="timezone-list" class="select-input timezone-input">
+                    <datalist id="timezone-list">
+                        {% for tz in timezones %}
+                        <option value="{{ tz }}">
+                        {% endfor %}
+                    </datalist>
                 </div>
             </div>
         </div>
@@ -132,6 +148,14 @@
                         <option value="slide-right">Slide Right</option>
                         <option value="zoom">Zoom</option>
                         <option value="none">None</option>
+                    </select>
+                </div>
+                <div class="setting-item">
+                    <label for="setting-fill-mode">Fill Mode</label>
+                    <select id="setting-fill-mode" class="select-input">
+                        <option value="blur">Blur</option>
+                        <option value="border">Border</option>
+                        <option value="zoom_to_fill">Zoom to Fill</option>
                     </select>
                 </div>
             </div>

--- a/src/smplfrm/smplfrm/views/index_view.py
+++ b/src/smplfrm/smplfrm/views/index_view.py
@@ -13,6 +13,8 @@ class IndexView(TemplateView):
     template_name = "index.html"
 
     def get_context_data(self, **kwargs):
+        from zoneinfo import available_timezones
+
         config = ConfigService().load_config()
 
         weather_enabled = "weather" in config.plugins
@@ -40,6 +42,7 @@ class IndexView(TemplateView):
             "plugin_spotify_enabled": str("spotify" in config.plugins).lower(),
             "image_zoom_effect": str(config.image_zoom_effect).lower(),
             "image_transition_type": config.image_transition_type,
+            "timezones": sorted(available_timezones()),
         }
 
         return context


### PR DESCRIPTION
## Summary

Add UI controls for the newly migrated Config fields. Subtask 4 of #132.

### Display Tab
- Searchable timezone input with `<datalist>` populated from Python `zoneinfo.available_timezones()` (max-width 280px)
- Date From File Path toggle with hover tooltip, positioned under Show Photo Date

### Images Tab
- Fill mode dropdown: Blur, Border, Zoom to Fill

### Other
- `loadConfig()` populates new fields from API response
- `saveConfig()` includes `timezone`, `image_fill_mode`, `force_date_from_path` in PUT payload
- Fix `select-input` width to size to content instead of stretching full width

### Tests
- 157 Python passed, 44 JS passed

Closes #136