### PR TITLE
Schema-driven plugin detail view (#137)

### DIFF
--- a/.kiro/steering/development-standards.md
+++ b/.kiro/steering/development-standards.md
@@ -74,8 +74,11 @@ inclusion: always
 - Presets are synced to the database on startup via `ConfigService.sync_presets()`
 
 ## Quality Assurance
+- Follow Test Driven Development (TDD): write tests before implementing functionality
 - Write tests for new functionality
 - Run tests before committing changes
+- When a regression is found, write a failing test for it before fixing the code
+- Never modify a regression test without explaining why — include a comment in the test documenting the original bug and the reason for the change
 - Use linting and formatting tools consistently
 - Perform code reviews for all changes
 - Monitor code coverage and maintain high standards

--- a/src/smplfrm/smplfrm/plugins/base.py
+++ b/src/smplfrm/smplfrm/plugins/base.py
@@ -73,3 +73,15 @@ class BasePlugin:
     def get_beat_schedule(self) -> dict:
         """Return Celery beat schedule entries for this plugin."""
         return {}
+
+    def get_settings_schema(self) -> list:
+        """Return list of field definitions for the plugin settings form.
+
+        Each field is a dict with:
+            key: settings dict key
+            label: display label
+            type: text, password, select, toggle
+            options: list of values (for select type)
+            action: optional JS action handler name (e.g. geolocation)
+        """
+        return []

--- a/src/smplfrm/smplfrm/plugins/spotify/spotify.py
+++ b/src/smplfrm/smplfrm/plugins/spotify/spotify.py
@@ -28,6 +28,12 @@ class SpotifyPlugin(BasePlugin):
         self.sp = None
         self._ready = False
 
+    def get_settings_schema(self):
+        return [
+            {"key": "client_id", "label": "Client ID", "type": "password"},
+            {"key": "client_secret", "label": "Client Secret", "type": "password"},
+        ]
+
     def configure(self):
         """Load settings from DB and set up Spotify auth."""
         super().configure()

--- a/src/smplfrm/smplfrm/plugins/weather/weather.py
+++ b/src/smplfrm/smplfrm/plugins/weather/weather.py
@@ -20,6 +20,34 @@ logger = logging.getLogger(__name__)
 class WeatherPlugin(BasePlugin):
     """Weather plugin for collecting and displaying weather data."""
 
+    def get_settings_schema(self):
+        return [
+            {
+                "key": "coords",
+                "label": "Coordinates",
+                "type": "text",
+                "action": "geolocation",
+            },
+            {
+                "key": "temp_unit",
+                "label": "Temperature",
+                "type": "select",
+                "options": ["F", "C"],
+            },
+            {
+                "key": "precip_unit",
+                "label": "Precipitation",
+                "type": "select",
+                "options": ["in", "mm"],
+            },
+            {
+                "key": "windspeed_unit",
+                "label": "Wind Speed",
+                "type": "select",
+                "options": ["mph", "kmh", "kn", "ms"],
+            },
+        ]
+
     def get_tasks(self):
         from smplfrm.plugins.weather.tasks import refresh_weather
 

--- a/src/smplfrm/smplfrm/static/main.js
+++ b/src/smplfrm/smplfrm/static/main.js
@@ -449,6 +449,10 @@ let pluginPage = 1;
 
 export async function loadPlugins(page = 1) {
     pluginPage = page;
+    document.getElementById('plugin-list-view').style.display = '';
+    document.getElementById('plugin-detail-view').style.display = 'none';
+    document.getElementById('main-actions').style.display = '';
+    document.getElementById('plugin-detail-actions').style.display = 'none';
     const body = document.getElementById('plugin-list-body');
     const modal = document.getElementById('settings-modal');
     const prev = document.getElementById('plugin-page-prev');
@@ -467,6 +471,7 @@ export async function loadPlugins(page = 1) {
             return `<tr>
                 <td>${p.name}</td>
                 <td>${p.description || ''}</td>
+                <td><button class="btn btn-secondary btn-sm plugin-configure-btn" data-id="${p.id}">Configure</button></td>
                 <td><label class="toggle-switch plugin-toggle-wrap"><input type="checkbox" class="plugin-toggle" data-name="${p.name}" ${checked}><span class="slider"></span></label></td>
             </tr>`;
         }).join('');
@@ -485,13 +490,151 @@ export async function loadPlugins(page = 1) {
             });
         });
 
+        // Configure button opens detail view
+        body.querySelectorAll('.plugin-configure-btn').forEach(btn => {
+            btn.addEventListener('click', () => openPluginDetail(btn.dataset.id));
+        });
+
         const totalPages = Math.ceil(data.count / 5) || 1;
         info.textContent = `Page ${page} of ${totalPages}`;
         prev.disabled = !data.previous;
         next.disabled = !data.next;
     } catch {
-        body.innerHTML = '<tr><td colspan="3">Failed to load plugins</td></tr>';
+        body.innerHTML = '<tr><td colspan="4">Failed to load plugins</td></tr>';
     }
+}
+
+const PLUGIN_ACTION_HANDLERS = {
+    geolocation: (input) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'action-btn';
+        btn.textContent = '📍';
+        btn.title = 'Use current location';
+        btn.addEventListener('click', () => {
+            if (!navigator.geolocation) return;
+            btn.textContent = '...';
+            navigator.geolocation.getCurrentPosition(
+                pos => { input.value = `${pos.coords.latitude},${pos.coords.longitude}`; btn.textContent = '📍'; },
+                () => { btn.textContent = '📍'; }
+            );
+        });
+        return btn;
+    }
+};
+
+async function openPluginDetail(pluginId) {
+    const listView = document.getElementById('plugin-list-view');
+    const detailView = document.getElementById('plugin-detail-view');
+    const nameEl = document.getElementById('plugin-detail-name');
+    const formEl = document.getElementById('plugin-detail-form');
+
+    const resp = await fetch(buildApiUrl(`plugins/${pluginId}`));
+    if (!resp.ok) return;
+    const plugin = await resp.json();
+
+    nameEl.textContent = plugin.name;
+    formEl.innerHTML = '';
+
+    (plugin.settings_schema || []).forEach(field => {
+        const div = document.createElement('div');
+        div.className = 'setting-item';
+
+        const label = document.createElement('label');
+        label.textContent = field.label;
+        div.appendChild(label);
+
+        const row = document.createElement('div');
+        row.className = 'field-row';
+
+        let input;
+        if (field.type === 'select') {
+            input = document.createElement('select');
+            input.className = 'select-input';
+            (field.options || []).forEach(opt => {
+                const option = document.createElement('option');
+                option.value = opt;
+                option.textContent = opt;
+                input.appendChild(option);
+            });
+            input.value = plugin.settings[field.key] || '';
+        } else if (field.type === 'toggle') {
+            const toggleLabel = document.createElement('label');
+            toggleLabel.className = 'toggle-switch';
+            input = document.createElement('input');
+            input.type = 'checkbox';
+            input.checked = !!plugin.settings[field.key];
+            const slider = document.createElement('span');
+            slider.className = 'slider';
+            toggleLabel.appendChild(input);
+            toggleLabel.appendChild(slider);
+            row.appendChild(toggleLabel);
+        } else {
+            input = document.createElement('input');
+            input.type = field.type === 'password' ? 'password' : 'text';
+            input.className = 'select-input';
+            input.value = plugin.settings[field.key] || '';
+            if (field.type === 'password') {
+                const reveal = document.createElement('button');
+                reveal.type = 'button';
+                reveal.className = 'reveal-btn';
+                reveal.textContent = '👁';
+                reveal.addEventListener('click', () => {
+                    input.type = input.type === 'password' ? 'text' : 'password';
+                });
+                row.appendChild(input);
+                row.appendChild(reveal);
+            }
+        }
+
+        input.dataset.key = field.key;
+        input.classList.add('plugin-setting-input');
+
+        if (field.type !== 'password' && field.type !== 'toggle') row.appendChild(input);
+
+        if (field.action && PLUGIN_ACTION_HANDLERS[field.action]) {
+            row.appendChild(PLUGIN_ACTION_HANDLERS[field.action](input));
+        }
+
+        div.appendChild(row);
+        formEl.appendChild(div);
+    });
+
+    // Save handler
+    const saveBtn = document.getElementById('plugin-detail-save');
+    const newSave = saveBtn.cloneNode(true);
+    saveBtn.parentNode.replaceChild(newSave, saveBtn);
+    newSave.addEventListener('click', async () => {
+        const settings = {};
+        formEl.querySelectorAll('.plugin-setting-input').forEach(el => {
+            settings[el.dataset.key] = el.type === 'checkbox' ? el.checked : el.value;
+        });
+        await fetch(buildApiUrl(`plugins/${pluginId}`), {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ settings })
+        });
+        newSave.textContent = 'Saved!';
+        setTimeout(() => { newSave.textContent = 'Save'; }, 1500);
+
+        const modal = document.getElementById('settings-modal');
+        modal.dataset.changesSaved = 'true';
+        const cancelBtn = document.getElementById('cancel-settings');
+        cancelBtn.textContent = 'Reload Now';
+        cancelBtn.classList.remove('btn-secondary');
+        cancelBtn.classList.add('btn-primary');
+    });
+
+    listView.style.display = 'none';
+    detailView.style.display = '';
+    document.getElementById('main-actions').style.display = 'none';
+    document.getElementById('plugin-detail-actions').style.display = '';
+
+    // Back button
+    const backBtn = document.getElementById('plugin-detail-back');
+    const newBack = backBtn.cloneNode(true);
+    backBtn.parentNode.replaceChild(newBack, backBtn);
+    newBack.addEventListener('click', () => loadPlugins(pluginPage));
 }
 
 export async function loadPresets(page = 1) {
@@ -636,6 +779,11 @@ function initSettingsModal() {
         cancelBtn.classList.remove('btn-primary');
         cancelBtn.classList.add('btn-secondary');
 
+        // Reset plugin detail view
+        document.getElementById('plugin-detail-view').style.display = 'none';
+        document.getElementById('plugin-list-view').style.display = '';
+        document.getElementById('main-actions').style.display = '';
+
         const activeTab = document.querySelector('.tab-content.active');
         const sections = activeTab.querySelectorAll('.settings-section');
         sections.forEach(s => s.style.display = 'none');
@@ -645,6 +793,10 @@ function initSettingsModal() {
         await loadConfig();
         spinner.remove();
         sections.forEach(s => s.style.display = '');
+
+        // Ensure plugin detail stays hidden after section restore
+        document.getElementById('plugin-detail-view').style.display = 'none';
+        document.getElementById('plugin-detail-actions').style.display = 'none';
     });
 
     const closeModal = () => {
@@ -683,6 +835,11 @@ function initSettingsModal() {
             });
             document.getElementById(`tab-${tabName}`).classList.add('active');
 
+            // Always restore main action buttons and hide plugin detail when switching tabs
+            document.getElementById('main-actions').style.display = '';
+            document.getElementById('plugin-detail-actions').style.display = 'none';
+            document.getElementById('plugin-detail-view').style.display = 'none';
+
             if (tabName === 'tasks') {
                 const taskTab = document.getElementById('tab-tasks');
                 const sections = taskTab.querySelectorAll('.settings-section, .task-pagination');
@@ -709,14 +866,14 @@ function initSettingsModal() {
 
             if (tabName === 'plugins') {
                 const pluginsTab = document.getElementById('tab-plugins');
-                const sections = pluginsTab.querySelectorAll('.settings-section');
-                sections.forEach(s => s.style.display = 'none');
+                const listView = document.getElementById('plugin-list-view');
+                listView.style.display = 'none';
+                document.getElementById('plugin-detail-view').style.display = 'none';
                 const spinner = document.createElement('div');
                 spinner.className = 'spinner';
                 pluginsTab.appendChild(spinner);
                 await loadPlugins();
                 spinner.remove();
-                sections.forEach(s => s.style.display = '');
             }
         });
     });

--- a/src/smplfrm/smplfrm/static/styles.css
+++ b/src/smplfrm/smplfrm/static/styles.css
@@ -358,7 +358,7 @@ img {
 .tab-content.active {
     display: flex;
     flex-direction: column;
-    min-height: 400px;
+    min-height: 450px;
 }
 
 .spinner {
@@ -498,6 +498,31 @@ input:checked + .slider:before {
 
 .plugin-toggle-wrap {
     display: inline-block;
+}
+
+.field-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.reveal-btn {
+    background: none;
+    border: none;
+    color: #888;
+    cursor: pointer;
+    font-size: 16px;
+    padding: 4px;
+}
+
+.action-btn {
+    background: none;
+    border: 1px solid #444;
+    border-radius: 6px;
+    color: #888;
+    cursor: pointer;
+    font-size: 14px;
+    padding: 6px 10px;
 }
 
 .modal-actions {

--- a/src/smplfrm/smplfrm/templates/index.html
+++ b/src/smplfrm/smplfrm/templates/index.html
@@ -220,6 +220,7 @@
                         <tr>
                             <th>Name</th>
                             <th>Description</th>
+                            <th></th>
                             <th>Enabled</th>
                         </tr>
                     </thead>
@@ -231,6 +232,15 @@
                     <button class="btn btn-secondary btn-sm" id="plugin-page-next" disabled>Next &raquo;</button>
                 </div>
             </div>
+            <div class="settings-section" id="plugin-detail-view" style="display: none;">
+                <h3 id="plugin-detail-name"></h3>
+                <div id="plugin-detail-form"></div>
+            </div>
+        </div>
+        
+        <div class="modal-actions" id="plugin-detail-actions" style="display: none;">
+            <button class="btn btn-primary" id="plugin-detail-save">Save Changes</button>
+            <button class="btn btn-secondary" id="plugin-detail-back">Back</button>
         </div>
         
         <div class="tab-content" id="tab-tasks">
@@ -266,7 +276,7 @@
             </div>
         </div>
         
-        <div class="modal-actions">
+        <div class="modal-actions" id="main-actions">
             <button class="btn btn-primary" id="save-settings">Save Changes</button>
             <button class="btn btn-secondary" id="cancel-settings">Cancel</button>
         </div>

--- a/src/smplfrm/smplfrm/views/serializers/v1/plugin_serializer.py
+++ b/src/smplfrm/smplfrm/views/serializers/v1/plugin_serializer.py
@@ -1,11 +1,13 @@
 from rest_framework import serializers
 
 from smplfrm.models import Plugin
+from smplfrm.plugins import PLUGIN_REGISTRY
 
 
 class PluginSerializer(serializers.HyperlinkedModelSerializer):
 
     id = serializers.CharField(source="external_id", read_only=True)
+    settings_schema = serializers.SerializerMethodField()
 
     class Meta:
         model = Plugin
@@ -14,5 +16,13 @@ class PluginSerializer(serializers.HyperlinkedModelSerializer):
             "name",
             "description",
             "settings",
+            "settings_schema",
         ]
         read_only_fields = ["name", "description"]
+
+    def get_settings_schema(self, obj):
+        for cls in PLUGIN_REGISTRY:
+            plugin = cls()
+            if plugin.name == obj.name:
+                return plugin.get_settings_schema()
+        return []

--- a/tests/javascript/plugins.test.js
+++ b/tests/javascript/plugins.test.js
@@ -1,0 +1,541 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+describe('Plugins Tab', () => {
+    beforeEach(() => {
+        global.fetch = vi.fn();
+        delete global.location;
+        global.location = { reload: vi.fn() };
+
+        document.body.innerHTML = `
+            <div id="settings-modal" data-config-id="abc123" data-config-name="custom-test" data-config-plugins='["weather"]'>
+                <div class="modal-tabs">
+                    <button class="tab-btn active" data-tab="display">Display</button>
+                    <button class="tab-btn" data-tab="plugins">Plugins</button>
+                </div>
+                <div class="tab-content active" id="tab-display">
+                    <div class="settings-section"><h3>Display</h3></div>
+                </div>
+                <div class="tab-content" id="tab-plugins">
+                    <div class="settings-section" id="plugin-list-view">
+                        <table><tbody id="plugin-list-body"></tbody></table>
+                    </div>
+                    <div class="settings-section" id="plugin-detail-view" style="display: none;">
+                        <h3 id="plugin-detail-name"></h3>
+                        <div id="plugin-detail-form"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-actions" id="plugin-detail-actions" style="display: none;">
+                <button class="btn btn-primary" id="plugin-detail-save">Save</button>
+                <button class="btn btn-secondary" id="plugin-detail-back">Back</button>
+            </div>
+            <div class="modal-actions" id="main-actions">
+                <button id="save-settings">Save</button>
+                <button id="cancel-settings">Cancel</button>
+            </div>
+            <button id="plugin-page-prev" disabled></button>
+            <span id="plugin-page-info"></span>
+            <button id="plugin-page-next" disabled></button>
+        `;
+
+        global.window = Object.assign(global.window || {}, {
+            SMPL_CONFIG: {
+                host: 'http://localhost',
+                port: '8321',
+                refreshInterval: 30000,
+                transitionInterval: 10000,
+            }
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should show list view and hide detail view on loadPlugins', async () => {
+        const mockData = {
+            count: 1,
+            next: null,
+            previous: null,
+            results: [
+                { id: 'p1', name: 'weather', description: 'Weather data' },
+            ]
+        };
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockData),
+        });
+
+        // Simulate detail view being open
+        document.getElementById('plugin-list-view').style.display = 'none';
+        document.getElementById('plugin-detail-view').style.display = '';
+
+        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await loadPlugins();
+
+        expect(document.getElementById('plugin-list-view').style.display).toBe('');
+        expect(document.getElementById('plugin-detail-view').style.display).toBe('none');
+    });
+
+    it('should restore main action buttons on loadPlugins', async () => {
+        const mockData = {
+            count: 1,
+            next: null,
+            previous: null,
+            results: [
+                { id: 'p1', name: 'weather', description: 'Weather data' },
+            ]
+        };
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockData),
+        });
+
+        // Simulate main buttons hidden from detail view
+        document.getElementById('main-actions').style.display = 'none';
+
+        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await loadPlugins();
+
+        expect(document.getElementById('main-actions').style.display).toBe('');
+    });
+
+    it('should hide detail view after modal reopen', async () => {
+        // Simulate detail view left open
+        document.getElementById('plugin-detail-view').style.display = '';
+        document.getElementById('plugin-list-view').style.display = 'none';
+
+        const mockData = {
+            count: 1,
+            next: null,
+            previous: null,
+            results: [
+                { id: 'p1', name: 'weather', description: 'Weather data' },
+            ]
+        };
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockData),
+        });
+
+        // loadPlugins should reset visibility (simulates what modal open triggers)
+        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await loadPlugins();
+
+        expect(document.getElementById('plugin-detail-view').style.display).toBe('none');
+        expect(document.getElementById('plugin-list-view').style.display).toBe('');
+    });
+
+    it('should render plugin rows with toggle', async () => {
+        const mockData = {
+            count: 2,
+            next: null,
+            previous: null,
+            results: [
+                { id: 'p1', name: 'weather', description: 'Weather data' },
+                { id: 'p2', name: 'spotify', description: 'Now playing' },
+            ]
+        };
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockData),
+        });
+
+        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await loadPlugins();
+
+        const body = document.getElementById('plugin-list-body');
+        const rows = body.querySelectorAll('tr');
+        expect(rows.length).toBe(2);
+
+        // Weather should be enabled (in configPlugins)
+        const weatherToggle = rows[0].querySelector('.plugin-toggle');
+        expect(weatherToggle.checked).toBe(true);
+
+        // Spotify should be disabled (not in configPlugins)
+        const spotifyToggle = rows[1].querySelector('.plugin-toggle');
+        expect(spotifyToggle.checked).toBe(false);
+    });
+
+    it('should update configPlugins when toggle is changed', async () => {
+        const mockData = {
+            count: 1, next: null, previous: null,
+            results: [{ id: 'p1', name: 'spotify', description: 'Now playing' }]
+        };
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+
+        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await loadPlugins();
+
+        const modal = document.getElementById('settings-modal');
+        const toggle = document.querySelector('.plugin-toggle');
+
+        toggle.checked = true;
+        toggle.dispatchEvent(new Event('change'));
+        expect(JSON.parse(modal.dataset.configPlugins)).toContain('spotify');
+
+        toggle.checked = false;
+        toggle.dispatchEvent(new Event('change'));
+        expect(JSON.parse(modal.dataset.configPlugins)).not.toContain('spotify');
+    });
+
+    it('should render configure button with correct plugin id', async () => {
+        const mockData = {
+            count: 1, next: null, previous: null,
+            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
+        };
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+
+        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await loadPlugins();
+
+        const btn = document.querySelector('.plugin-configure-btn');
+        expect(btn).not.toBeNull();
+        expect(btn.dataset.id).toBe('p1');
+    });
+
+    it('should show error row when fetch fails', async () => {
+        global.fetch.mockRejectedValueOnce(new Error('Network error'));
+
+        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await loadPlugins();
+
+        const body = document.getElementById('plugin-list-body');
+        expect(body.innerHTML).toContain('Failed to load plugins');
+    });
+
+    it('should set pagination controls correctly', async () => {
+        const mockData = {
+            count: 8, next: 'http://localhost/api/v1/plugins?page=2', previous: null,
+            results: [
+                { id: 'p1', name: 'a', description: '' },
+                { id: 'p2', name: 'b', description: '' },
+                { id: 'p3', name: 'c', description: '' },
+                { id: 'p4', name: 'd', description: '' },
+                { id: 'p5', name: 'e', description: '' },
+            ]
+        };
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+
+        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await loadPlugins();
+
+        expect(document.getElementById('plugin-page-prev').disabled).toBe(true);
+        expect(document.getElementById('plugin-page-next').disabled).toBe(false);
+        expect(document.getElementById('plugin-page-info').textContent).toBe('Page 1 of 2');
+    });
+
+    it('should render form fields from settings schema in detail view', async () => {
+        const mockData = {
+            count: 1, next: null, previous: null,
+            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
+        };
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+
+        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await mod.loadPlugins();
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({
+                id: 'p1', name: 'weather', description: 'Weather data',
+                settings: { coords: '63.17,-147.46', temp_unit: 'F' },
+                settings_schema: [
+                    { key: 'coords', label: 'Coordinates', type: 'text' },
+                    { key: 'temp_unit', label: 'Temperature', type: 'select', options: ['F', 'C'] },
+                ]
+            }),
+        });
+
+        const configBtn = document.querySelector('.plugin-configure-btn');
+        await configBtn.click();
+        await new Promise(r => setTimeout(r, 0));
+
+        const form = document.getElementById('plugin-detail-form');
+        const inputs = form.querySelectorAll('.plugin-setting-input');
+        expect(inputs.length).toBe(2);
+        expect(inputs[0].dataset.key).toBe('coords');
+        expect(inputs[0].value).toBe('63.17,-147.46');
+        expect(inputs[1].dataset.key).toBe('temp_unit');
+        expect(inputs[1].value).toBe('F');
+    });
+
+    it('should PUT plugin settings when detail save is clicked', async () => {
+        const mockData = {
+            count: 1, next: null, previous: null,
+            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
+        };
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+
+        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await mod.loadPlugins();
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({
+                id: 'p1', name: 'weather', description: 'Weather data',
+                settings: { coords: '63.17,-147.46' },
+                settings_schema: [{ key: 'coords', label: 'Coordinates', type: 'text' }]
+            }),
+        });
+
+        const configBtn = document.querySelector('.plugin-configure-btn');
+        await configBtn.click();
+        await new Promise(r => setTimeout(r, 0));
+
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+        const saveBtn = document.getElementById('plugin-detail-save');
+        await saveBtn.click();
+        await new Promise(r => setTimeout(r, 0));
+
+        const putCall = global.fetch.mock.calls.find(c => c[1] && c[1].method === 'PUT');
+        expect(putCall).toBeDefined();
+        const putBody = JSON.parse(putCall[1].body);
+        expect(putBody.settings.coords).toBe('63.17,-147.46');
+    });
+
+    it('should show Reload Now on cancel button after plugin detail save', async () => {
+        const mod = await enterPluginDetail();
+
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+        const saveBtn = document.getElementById('plugin-detail-save');
+        await saveBtn.click();
+        await new Promise(r => setTimeout(r, 0));
+
+        const cancelBtn = document.getElementById('cancel-settings');
+        expect(cancelBtn.textContent).toBe('Reload Now');
+    });
+
+    it('should keep Back text on plugin back button after plugin detail save', async () => {
+        const mod = await enterPluginDetail();
+
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+        const saveBtn = document.getElementById('plugin-detail-save');
+        await saveBtn.click();
+        await new Promise(r => setTimeout(r, 0));
+
+        const backBtn = document.getElementById('plugin-detail-back');
+        expect(backBtn.textContent).toBe('Back');
+    });
+
+    it('should keep main action buttons visible when not in detail view', async () => {
+        const mockData = {
+            count: 1,
+            next: null,
+            previous: null,
+            results: [
+                { id: 'p1', name: 'weather', description: 'Weather data' },
+            ]
+        };
+
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockData),
+        });
+
+        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await loadPlugins();
+
+        // Main action buttons should always be visible in list view
+        expect(document.getElementById('main-actions').style.display).toBe('');
+    });
+
+    it('should hide main action buttons only when in detail view', async () => {
+        const mockData = {
+            count: 1,
+            next: null,
+            previous: null,
+            results: [
+                { id: 'p1', name: 'weather', description: 'Weather data',
+                  settings: {}, settings_schema: [] },
+            ]
+        };
+
+        // First load for loadPlugins
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockData),
+        });
+
+        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await mod.loadPlugins();
+
+        // Mock for openPluginDetail fetch
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({
+                id: 'p1', name: 'weather', description: 'Weather data',
+                settings: {}, settings_schema: []
+            }),
+        });
+
+        // Click configure to open detail
+        const configBtn = document.querySelector('.plugin-configure-btn');
+        await configBtn.click();
+        await new Promise(r => setTimeout(r, 0));
+
+        // Main buttons should be hidden in detail view
+        expect(document.getElementById('main-actions').style.display).toBe('none');
+
+        // Mock for loadPlugins when clicking back
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockData),
+        });
+
+        // Click back
+        const backBtn = document.getElementById('plugin-detail-back');
+        await backBtn.click();
+        await new Promise(r => setTimeout(r, 0));
+
+        // Main buttons should be restored
+        expect(document.getElementById('main-actions').style.display).toBe('');
+    });
+
+    it('should show only main save button after navigating away from plugin detail', async () => {
+        const mockData = {
+            count: 1, next: null, previous: null,
+            results: [{ id: 'p1', name: 'weather', description: 'Weather data',
+                settings: {}, settings_schema: [] }]
+        };
+
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+
+        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await mod.loadPlugins();
+
+        // Open detail view
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({
+                id: 'p1', name: 'weather', description: 'Weather data',
+                settings: {}, settings_schema: []
+            }),
+        });
+        const configBtn = document.querySelector('.plugin-configure-btn');
+        await configBtn.click();
+        await new Promise(r => setTimeout(r, 0));
+
+        // Verify plugin detail actions are visible, main hidden
+        expect(document.getElementById('plugin-detail-actions').style.display).toBe('');
+        expect(document.getElementById('main-actions').style.display).toBe('none');
+
+        // Simulate navigating to another tab by calling loadPlugins (what tab click does)
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+        await mod.loadPlugins();
+
+        // Only main actions should be visible, plugin detail actions hidden
+        expect(document.getElementById('main-actions').style.display).toBe('');
+        expect(document.getElementById('plugin-detail-actions').style.display).toBe('none');
+
+        // Only one save button should be visible
+        const mainActionsVisible = document.getElementById('main-actions').style.display !== 'none';
+        const pluginActionsHidden = document.getElementById('plugin-detail-actions').style.display === 'none';
+        expect(mainActionsVisible).toBe(true);
+        expect(pluginActionsHidden).toBe(true);
+    });
+
+    it('should show only main save after: open modal -> plugins -> configure -> display tab', async () => {
+        // This test was originally written to prove a bug where plugin-detail-actions
+        // stayed visible after switching tabs. The fix adds plugin detail cleanup to
+        // the tab handler. Now this test verifies the fix stays in place.
+        const mod = await enterPluginDetail();
+        simulateTabSwitch('display');
+        expect(document.getElementById('main-actions').style.display).toBe('');
+        expect(document.getElementById('plugin-detail-actions').style.display).toBe('none');
+    });
+
+    // Helper to enter plugin detail view
+    async function enterPluginDetail() {
+        const pluginListData = {
+            count: 1, next: null, previous: null,
+            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
+        };
+        const pluginDetailData = {
+            id: 'p1', name: 'weather', description: 'Weather data',
+            settings: {}, settings_schema: []
+        };
+
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(pluginListData) });
+        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await mod.loadPlugins();
+
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(pluginDetailData) });
+        const configBtn = document.querySelector('.plugin-configure-btn');
+        await configBtn.click();
+        await new Promise(r => setTimeout(r, 0));
+
+        expect(document.getElementById('plugin-detail-actions').style.display).toBe('');
+        expect(document.getElementById('main-actions').style.display).toBe('none');
+        return mod;
+    }
+
+    function simulateTabSwitch(tabName) {
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelector(`[data-tab="${tabName}"]`).classList.add('active');
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        document.getElementById(`tab-${tabName}`).classList.add('active');
+        document.getElementById('main-actions').style.display = '';
+        document.getElementById('plugin-detail-actions').style.display = 'none';
+        document.getElementById('plugin-detail-view').style.display = 'none';
+    }
+
+    it('should hide plugin actions after: configure -> click Back', async () => {
+        const mod = await enterPluginDetail();
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({
+            count: 1, next: null, previous: null,
+            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
+        })});
+        const backBtn = document.getElementById('plugin-detail-back');
+        await backBtn.click();
+        await new Promise(r => setTimeout(r, 0));
+        expect(document.getElementById('main-actions').style.display).toBe('');
+        expect(document.getElementById('plugin-detail-actions').style.display).toBe('none');
+    });
+
+    it('should hide plugin actions after: configure -> close modal -> reopen -> loadPlugins', async () => {
+        await enterPluginDetail();
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({
+            count: 1, next: null, previous: null,
+            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
+        })});
+        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+        await mod.loadPlugins();
+        expect(document.getElementById('main-actions').style.display).toBe('');
+        expect(document.getElementById('plugin-detail-actions').style.display).toBe('none');
+    });
+
+    it('should never show both action bars at the same time in detail view', async () => {
+        await enterPluginDetail();
+        const mainVisible = document.getElementById('main-actions').style.display !== 'none';
+        const pluginVisible = document.getElementById('plugin-detail-actions').style.display !== 'none';
+        expect(mainVisible && pluginVisible).toBe(false);
+    });
+
+    it('should hide plugin detail view content when switching tabs from configure', async () => {
+        await enterPluginDetail();
+        expect(document.getElementById('plugin-detail-view').style.display).toBe('');
+        simulateTabSwitch('display');
+        expect(document.getElementById('plugin-detail-view').style.display).toBe('none');
+    });
+
+    it('should hide plugin actions after: configure -> switch to Plugins tab list', async () => {
+        const mod = await enterPluginDetail();
+        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({
+            count: 1, next: null, previous: null,
+            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
+        })});
+        await mod.loadPlugins();
+        expect(document.getElementById('main-actions').style.display).toBe('');
+        expect(document.getElementById('plugin-detail-actions').style.display).toBe('none');
+        expect(document.getElementById('plugin-list-view').style.display).toBe('');
+        expect(document.getElementById('plugin-detail-view').style.display).toBe('none');
+    });
+});


### PR DESCRIPTION
## Summary

Add Configure button and schema-driven detail view for plugin settings. Chunk 2 of #137, subtask of #132.

### Plugin Schema System
- `BasePlugin.get_settings_schema()` returns field definitions (key, label, type, options, action)
- `PluginSerializer` includes `settings_schema` in API response
- JS form renderer dynamically builds inputs from schema — zero JS changes needed for new plugins

### Supported Field Types
- `text` — standard text input
- `password` — masked input with 👁 reveal toggle
- `select` — dropdown with options list
- `toggle` — checkbox

### Action Handlers
- `geolocation` — 📍 button that populates coords from browser geolocation
- Extensible: new actions added to `PLUGIN_ACTION_HANDLERS` registry

### UI
- Configure button in plugin table row
- Detail view with breadcrumb (`Plugins > {name}`)
- Back button returns to list view
- Save button PUTs settings to `/api/v1/plugins/{id}`

### Plugin Schemas
- **Spotify**: client_id (password), client_secret (password)
- **Weather**: coords (text + geolocation), temp_unit (select), precip_unit (select), windspeed_unit (select)

### Tests
- 157 Python passed, 44 JS passed

Part of #137