### PR TITLE
Update Settings wiki for config migration (#138)

### DIFF
--- a/.kiro/steering/development-standards.md
+++ b/.kiro/steering/development-standards.md
@@ -43,7 +43,7 @@ inclusion: always
 - The project wiki lives in the `docs/` folder and is synced to the GitHub wiki on push to main
 - When user-facing functionality is added or changed, update the relevant wiki page in `docs/`
 - Wiki pages to keep in sync:
-  - `Settings.md` — documents the settings modal tabs (Display, Images, Library, About)
+  - `Settings.md` — documents the settings modal tabs (Display, Images, Library, Presets, Plugins, Tasks, About)
 - Add screenshots to `docs/images/` when UI changes are significant
 - Update `Home.md` links when new pages are added
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1,6 +1,40 @@
 # Settings
 
-The settings modal can be accessed by clicking the SmplFrm icon in the top-right corner of the display. It contains tabs for Display, Images, Library, Presets, Tasks, and About.
+The settings modal can be accessed by clicking the SmplFrm icon in the top-right corner of the display. It contains tabs for Display, Images, Library, Presets, Plugins, Tasks, and About.
+
+## Display
+
+The Display tab controls what information is shown on the photo frame overlay.
+
+![Display Settings](images/settings/displaySettings.png)
+
+| Setting | Description |
+|---------|-------------|
+| Show Photo Date | Display the date (Month, Year) of the photo from EXIF data or file path. |
+| Date From File Path | Use the file path (YYYY/MM) to determine the photo date instead of EXIF data. |
+| Show Date And Time | Display the current date and time. |
+| Timezone | Timezone for the clock display. Searchable input with all IANA timezones. |
+
+## Images
+
+The Images tab controls image display timing, effects, and processing.
+
+![Images Settings](images/settings/imagesSettings.png)
+
+### Timing
+
+| Setting | Description | Range |
+|---------|-------------|-------|
+| Refresh Interval | How long to display an image (milliseconds). | 5 – 300 |
+| Transition Time | How long the transition between images takes (milliseconds). | 1000 – 300000 |
+
+### Effects
+
+| Setting | Description |
+|---------|-------------|
+| Zoom Effect | Enables slow zoom animation on images (1.0x to 1.2x scale over display duration). |
+| Transition Type | Image transition effect: Random, Fade, Slide Left, Slide Right, Zoom, or None. |
+| Fill Mode | How to fill aspect ratio gaps: Blur (blurred background), Border (replicate edges), or Zoom to Fill. |
 
 ## Library
 
@@ -45,6 +79,45 @@ The Presets tab displays all configuration presets and custom configs. It allows
 - **Custom configs** can be renamed, have their description edited, and be deleted (if not active).
 - A maximum of 10 configs can exist at a time.
 
+## Plugins
+
+The Plugins tab shows all registered plugins with enable/disable toggles and per-plugin configuration.
+
+![Plugins Settings](images/settings/pluginsSettings.png)
+
+| Column | Description |
+|--------|-------------|
+| Name | The plugin name. |
+| Description | Brief description of the plugin. |
+| Configure | Opens the plugin's settings form. |
+| Enabled | Toggle to enable or disable the plugin. Saved with the main Save button. |
+
+### Configure
+
+Clicking Configure opens a detail view with plugin-specific settings. The form fields are defined by each plugin's schema — no core code changes are needed when adding a new plugin.
+
+![Plugin Configure](images/settings/pluginConfigure.png)
+
+#### Spotify
+
+| Setting | Description |
+|---------|-------------|
+| Client ID | Spotify API client ID. Masked by default with reveal toggle. |
+| Client Secret | Spotify API client secret. Masked by default with reveal toggle. |
+
+See [Spotify Developer](https://spotipy.readthedocs.io/en/latest/#getting-started) for setup instructions.
+
+#### Weather
+
+| Setting | Description |
+|---------|-------------|
+| Coordinates | Lat,Long for weather location. Use 📍 button for browser geolocation. |
+| Temperature | Temperature unit: F (Fahrenheit) or C (Celsius). |
+| Precipitation | Precipitation unit: in (inches) or mm (millimeters). |
+| Wind Speed | Wind speed unit: mph, kmh, kn, or ms. |
+
+[Weather data by Open-Meteo.com](https://open-meteo.com)
+
 ## Tasks
 
 The Tasks tab displays a history of background tasks. Each row shows the task type, status, progress, and creation date. Tasks are sorted newest-first and paginated with 5 per page.
@@ -63,4 +136,4 @@ Each row includes a delete button (×) that deletes the task. If the task is cur
 
 Only one task of each type can be pending or running at a time. Attempting to start a duplicate will show an error in the toast.
 
-Tasks that were created more than 7 days ago will be deleted. 
+Tasks that were created more than 7 days ago will be deleted.


### PR DESCRIPTION
## Summary

Update project documentation to cover all new settings, plugins tab, and config fields. Final subtask of #132.

### Changes
- **Settings.md**: Full rewrite with all 7 tabs documented
  - Display: photo date, date from path, clock, timezone
  - Images: timing, effects, fill mode
  - Library: cache, maintenance (unchanged)
  - Presets: (unchanged)
  - Plugins: list view with enable/disable, configure detail view
  - Tasks: (unchanged)
  - About: (unchanged)
- **Steering docs**: Updated wiki page reference with all current tabs

Closes #138