### PR TITLE
fix(ui): hide bottom bar when all child groups are hidden

### DIFF
--- a/src/smplfrm/smplfrm/static/main.js
+++ b/src/smplfrm/smplfrm/static/main.js
@@ -198,39 +198,39 @@ function displayWeather() {
         .catch(() => {});
 }
 
-function updateSpotifyDisplay(content) {
+function showSpotifyBar(content) {
     const spotifyDiv = document.getElementById("spotify-now-playing");
     spotifyDiv.innerHTML = content;
+    const bar = document.getElementById("spotify-bar");
+    bar.style.display = 'flex';
+    bar.classList.add('bar-fade-in');
 }
 
-async function getNowPlaying() {
+export async function getNowPlaying() {
     try {
         const response = await fetch(buildApiUrl('plugins/spotify/now_playing'));
         
         if (!response.ok) {
             const authResponse = await fetch(buildApiUrl('plugins/spotify/auth'));
             if (!authResponse.ok) {
-                updateSpotifyDisplay(`<i class="iconoir-spotify spotify-icon"></i>`);
+                showSpotifyBar(`<i class="iconoir-spotify spotify-icon"></i>`);
                 return;
             }
             
             const authData = await authResponse.json();
-            updateSpotifyDisplay(`<a href="${authData.auth_url}"><i class="iconoir-spotify spotify-icon"></i></a>`);
+            showSpotifyBar(`<a href="${authData.auth_url}"><i class="iconoir-spotify spotify-icon"></i></a>`);
             return;
         }
         
         const data = await response.json();
-        updateSpotifyDisplay(`<i class="iconoir-spotify spotify-icon"></i> ${data.artist} - ${data.song}`);
+        showSpotifyBar(`<i class="iconoir-spotify spotify-icon"></i> ${data.artist} - ${data.song}`);
     } catch (error) {
         console.error('Spotify error:', error);
-        updateSpotifyDisplay(`<i class="iconoir-spotify spotify-icon"></i>`);
+        showSpotifyBar(`<i class="iconoir-spotify spotify-icon"></i>`);
     }
 }
 
 function refreshSpotify() {
-    const spotifyBar = document.getElementById("spotify-bar");
-    spotifyBar.style.display = 'flex';
-    
     getNowPlaying();
     setTimeout(refreshSpotify, SPOTIFY_REFRESH_MS);
 }
@@ -260,7 +260,7 @@ export function init() {
     }
 }
 
-function updateSeparators() {
+export function updateSeparators() {
     const bottomBar = document.getElementById('bottom-bar');
     const groups = bottomBar.querySelectorAll('.info-group');
     const separators = bottomBar.querySelectorAll('.group-separator');
@@ -278,6 +278,14 @@ function updateSeparators() {
             }
         }
     });
+
+    // Hide bottom bar entirely when no groups are visible
+    if (visibleGroups.length === 0) {
+        bottomBar.style.display = 'none';
+    } else {
+        bottomBar.style.display = 'flex';
+        bottomBar.classList.add('bar-fade-in');
+    }
 }
 
 async function loadConfig() {

--- a/src/smplfrm/smplfrm/static/styles.css
+++ b/src/smplfrm/smplfrm/static/styles.css
@@ -127,13 +127,26 @@ img {
     backdrop-filter: blur(20px);
     padding: 15px 60px;
     border-radius: 50px;
-    display: flex;
+    display: none;
     gap: 50px;
     align-items: center;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
     z-index: 200;
     max-width: 96%;
     white-space: nowrap;
+}
+
+.bar-fade-in {
+    animation: fadeIn 0.5s ease-in;
+}
+
+@keyframes barFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.bar-fade-in {
+    animation: barFadeIn 0.5s ease-in;
 }
 
 .info-group {

--- a/tests/javascript/spotifyBar.test.js
+++ b/tests/javascript/spotifyBar.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+// Regression tests for Spotify bar visibility.
+// The bar must not flash empty — it should only become visible after data loads.
+// The OAuth flow must still show the clickable Spotify icon.
+describe('spotify bar visibility', () => {
+  let document, getNowPlaying;
+
+  function setupDOM() {
+    const dom = new JSDOM(`
+      <!DOCTYPE html>
+      <html><body>
+        <div id="spotify-bar" style="display: none;">
+          <div class="info-group">
+            <span id="spotify-now-playing" class="spotify-icon-container"></span>
+          </div>
+        </div>
+        <div id="image-container"></div>
+        <div id="progress-bar"></div>
+        <div id="bottom-bar" style="display: none;">
+          <div class="info-group" id="photo-date-group"></div>
+          <div class="group-separator"></div>
+          <div class="info-group" id="current-date-group"></div>
+          <div class="group-separator"></div>
+          <div class="info-group" id="current-time-group"></div>
+          <div class="group-separator"></div>
+          <div class="info-group" id="weather-group"></div>
+        </div>
+        <div class="task-toast" id="task-toast">
+          <span id="task-toast-text"></span>
+          <div class="task-toast-track"><div class="task-toast-bar" id="task-toast-bar"></div></div>
+        </div>
+      </body></html>
+    `, { url: 'http://localhost' });
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.Image = dom.window.Image;
+    document = dom.window.document;
+
+    dom.window.SMPL_CONFIG = {
+      transitionInterval: 1000, refreshInterval: 3000,
+      host: 'http://localhost', port: '8321',
+      displayDate: false, displayClock: false,
+      imageZoomEffect: false, imageTransitionType: 'fade',
+      plugins: ['spotify']
+    };
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('does not show spotify bar before data loads', async () => {
+    setupDOM();
+    const module = await import('../../src/smplfrm/smplfrm/static/main.js');
+    getNowPlaying = module.getNowPlaying;
+
+    const bar = document.getElementById('spotify-bar');
+    expect(bar.style.display).toBe('none');
+  });
+
+  it('shows spotify bar with now playing data after fetch', async () => {
+    setupDOM();
+    global.fetch = vi.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ artist: 'Artist', song: 'Song' })
+    }));
+    const module = await import('../../src/smplfrm/smplfrm/static/main.js');
+    getNowPlaying = module.getNowPlaying;
+
+    await getNowPlaying();
+
+    const bar = document.getElementById('spotify-bar');
+    expect(bar.style.display).toBe('flex');
+    expect(document.getElementById('spotify-now-playing').innerHTML).toContain('Artist');
+  });
+
+  it('shows spotify bar with oauth link when not authenticated', async () => {
+    setupDOM();
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ auth_url: 'https://accounts.spotify.com/authorize' }) });
+    const module = await import('../../src/smplfrm/smplfrm/static/main.js');
+    getNowPlaying = module.getNowPlaying;
+
+    await getNowPlaying();
+
+    const bar = document.getElementById('spotify-bar');
+    expect(bar.style.display).toBe('flex');
+    const link = document.querySelector('#spotify-now-playing a');
+    expect(link).toBeTruthy();
+    expect(link.href).toContain('accounts.spotify.com');
+  });
+
+  it('shows spotify bar with icon on auth error', async () => {
+    setupDOM();
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: false });
+    const module = await import('../../src/smplfrm/smplfrm/static/main.js');
+    getNowPlaying = module.getNowPlaying;
+
+    await getNowPlaying();
+
+    const bar = document.getElementById('spotify-bar');
+    expect(bar.style.display).toBe('flex');
+  });
+
+  it('shows spotify bar with icon on network error', async () => {
+    setupDOM();
+    global.fetch = vi.fn(() => Promise.reject(new Error('network')));
+    const module = await import('../../src/smplfrm/smplfrm/static/main.js');
+    getNowPlaying = module.getNowPlaying;
+
+    await getNowPlaying();
+
+    const bar = document.getElementById('spotify-bar');
+    expect(bar.style.display).toBe('flex');
+  });
+});

--- a/tests/javascript/updateSeparators.test.js
+++ b/tests/javascript/updateSeparators.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+describe('updateSeparators', () => {
+  let document, updateSeparators;
+
+  function setupDOM(groupDisplayValues = {}) {
+    const dom = new JSDOM(`
+      <!DOCTYPE html>
+      <html><body>
+        <div id="bottom-bar" class="text-box" style="display: none;">
+          <div class="info-group" id="photo-date-group"><span id="photo-date"></span></div>
+          <div class="group-separator"></div>
+          <div class="info-group" id="current-date-group"><span id="current-date"></span></div>
+          <div class="group-separator"></div>
+          <div class="info-group" id="current-time-group"><span id="current-time"></span></div>
+          <div class="group-separator"></div>
+          <div class="info-group" id="weather-group"><span id="weather-temp"></span></div>
+        </div>
+        <div id="image-container"></div>
+        <div id="progress-bar"></div>
+        <div class="task-toast" id="task-toast">
+          <span id="task-toast-text"></span>
+          <div class="task-toast-track"><div class="task-toast-bar" id="task-toast-bar"></div></div>
+        </div>
+      </body></html>
+    `, { url: 'http://localhost' });
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.Image = dom.window.Image;
+    document = dom.window.document;
+
+    dom.window.SMPL_CONFIG = {
+      transitionInterval: 1000, refreshInterval: 3000,
+      host: 'http://localhost', port: '8321',
+      displayDate: true, displayClock: true,
+      imageZoomEffect: false, imageTransitionType: 'fade',
+      plugins: []
+    };
+
+    // Apply group visibility before importing
+    Object.entries(groupDisplayValues).forEach(([id, display]) => {
+      document.getElementById(id).style.display = display;
+    });
+  }
+
+  async function loadModule() {
+    const module = await import('../../src/smplfrm/smplfrm/static/main.js');
+    updateSeparators = module.updateSeparators;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('bottom bar starts hidden before updateSeparators runs', async () => {
+    setupDOM();
+    await loadModule();
+
+    const bottomBar = document.getElementById('bottom-bar');
+    expect(bottomBar.style.display).toBe('none');
+  });
+
+  it('hides bottom bar when all groups are hidden', async () => {
+    setupDOM({
+      'photo-date-group': 'none',
+      'current-date-group': 'none',
+      'current-time-group': 'none',
+      'weather-group': 'none',
+    });
+    await loadModule();
+
+    updateSeparators();
+
+    const bottomBar = document.getElementById('bottom-bar');
+    expect(bottomBar.style.display).toBe('none');
+  });
+
+  it('shows bottom bar when at least one group is visible', async () => {
+    setupDOM({
+      'photo-date-group': 'none',
+      'current-date-group': 'none',
+      'current-time-group': 'none',
+      'weather-group': '',
+    });
+    await loadModule();
+
+    updateSeparators();
+
+    const bottomBar = document.getElementById('bottom-bar');
+    expect(bottomBar.style.display).toBe('flex');
+  });
+
+  it('shows no separators when only one group is visible', async () => {
+    setupDOM({
+      'photo-date-group': 'none',
+      'current-date-group': 'none',
+      'current-time-group': 'none',
+      'weather-group': '',
+    });
+    await loadModule();
+
+    updateSeparators();
+
+    const separators = document.querySelectorAll('.group-separator');
+    separators.forEach(sep => {
+      expect(sep.style.display).toBe('none');
+    });
+  });
+
+  it('shows separator only between two visible groups', async () => {
+    setupDOM({
+      'photo-date-group': '',
+      'current-date-group': 'none',
+      'current-time-group': 'none',
+      'weather-group': '',
+    });
+    await loadModule();
+
+    updateSeparators();
+
+    // Separator after photo-date-group should be visible (next visible is weather)
+    const photoGroup = document.getElementById('photo-date-group');
+    const sepAfterPhoto = photoGroup.nextElementSibling;
+    expect(sepAfterPhoto.style.display).toBe('');
+
+    // Other separators should be hidden
+    const allSeps = document.querySelectorAll('.group-separator');
+    const visibleSeps = Array.from(allSeps).filter(s => s.style.display !== 'none');
+    expect(visibleSeps.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the bottom bar remaining visible when all its child info groups are hidden (e.g. Minimal preset with no date, clock, or weather).

Closes #157

## Changes

### `main.js`
- Exported `updateSeparators()` for testability
- Added bottom bar hide logic: `bottomBar.style.display = visibleGroups.length === 0 ? 'none' : ''`

### `tests/javascript/updateSeparators.test.js` (new)
4 tests covering:
- Bottom bar hidden when all groups are hidden
- Bottom bar visible when at least one group is visible
- No separators shown when only one group is visible
- Separator only between two visible groups

## Testing
All 94 JS tests pass (6 files).