### PR TITLE
refactor(docker): consolidate into single container + update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,30 +25,32 @@ ___
 * Add your own assets to the `assets` folder and re-run the server to display your own photos
 
 ### Docker
-* Build the dockerfile
-  * `docker build -t smplFrm .`
-* Run the docker file exposing ports
-  * `docker run -p 8321:8321`
-* Browse to `http://localhost:8321`
-* To add your own as assets mount a local volume to the `/app/assets` folder in the image
-  * `docker run -p 8321:8321 -v <local/Folder/Path>:/app/assets smpl_frm`
+The recommended way to run smplFrm is with Docker Compose. The image bundles the web server, Celery worker, and Celery beat into a single container — only Redis is needed as a separate service.
+
 ### Docker Compose
-* An example compose file exists at [compose.yaml](docker/compose/compose.yaml)
-* Essentially you just need to update the `SMPL_FRM_ASSET_DIRECTORIES` and mount a local volume like below
-```
+Create a `compose.yaml` with the following (or use the one at [docker/compose/compose.yaml](docker/compose/compose.yaml)):
+```yaml
 services:
     smpl_frm:
         image: dke39vsh3gghs/smplfrm:latest
         ports:
-         - "8321:8321"
+          - "8321:8321"
         environment:
-            - SMPL_FRM_LIBRARY_DIRS=/app/library,/app/assets
+            - SMPL_FRM_LIBRARY_DIRS=/app/library
+            - REDIS_HOST=cache
             - PYTHONUNBUFFERED=1
         volumes:
-            - /example/local/library/here:/app/library
+            - /path/to/your/photos:/app/library
+        depends_on:
+          - cache
 
+    cache:
+        image: redis:7.4.1-alpine
+        restart: always
 ```
-* Then run `docker-compose up -d` and browse to `http://localhost:8321`
+Run `docker compose up -d` and browse to `http://localhost:8321`.
+
+For detailed configuration see the [Docker wiki page](https://github.com/rickyphewitt/smplFrm/wiki/Docker).
 
 ### Docker Hub Labels
 Repo: https://hub.docker.com/r/dke39vsh3gghs/smplfrm
@@ -58,6 +60,9 @@ Repo: https://hub.docker.com/r/dke39vsh3gghs/smplfrm
   * This is the most recent code on `main`. Useful for development and testing.
 * `<commit-hash>`
   * For each commit merged into `main` an image is created with the corresponding git hash. Useful for pinning to a specific version outside the release cycle. 
+
+### Environment variables
+For a full list of environment variables see the [Environment Variable wiki page](https://github.com/rickyphewitt/smplFrm/wiki/Environment-Variables)
 
 ## Development
 
@@ -105,41 +110,4 @@ However, there are some additional guidelines that should be used for AI commits
 
 ### Environment Variables
 
-| Name                                    | Default                            | Description                                                                                                               |
-|-----------------------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `SMPL_FRM_LIBRARY_DIRS`                 | "<settings.py-dir>./../../library" | Comma Separated String of directory paths                                                                                 |
-| `SMPL_FRM_IMAGE_FORMATS`                | "jpg,png"                          | Comma Separated String of directory paths                                                                                 |
-| `SMPL_FRM_IMAGE_REFRESH_INTERVAL`       | 30000                              | How long to display an image (millis)                                                                                     |
-| `SMPL_FRM_IMAGE_TRANSITION_INTERVAL`    | 10000                              | How long to transition the image (millis)                                                                                 |
-| `SMPL_FRM_EXTERNAL_PORT`                | 8321                               | Used in Docker when the external port differs from the server port                                                        |
-| `SMPL_FRM_HOST`                         | localhost                          | Used when running the application on a server                                                                             |
-| `SMPL_FRM_PROTOCOL`                     | "http://"                          | Set to "https://" for ssl                                                                                                 |
-| `SMPL_FRM_DISPLAY_DATE`                 | True                               | Display date (Month, Year) of photo. This reads the exif image data                                                       |
-| `SMPL_FRM_FORCE_DATE_FROM_PATH`         | True                               | Use the filepath to determine date supports `YYYY/MM` 2024/12                                                             |
-| `SMPL_FRM_DISPLAY_CLOCK`                | True                               | Display the Clock                                                                                                         |
-| `SMPL_FRM_DISPLAY_WEATHER`              | True                               | Display the Weather. [Weather data by Open-Meteo.com](https://open-meteo.com)                                             |
-| `SMPL_FRM_TIMEZONE`                     | "America/Los_Angeles"              | TZ Identified from [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)                              |
-| `SMPL_FRM_IMAGE_CACHE_TIMEOUT`          | "300"                              | Seconds until the image should be removed from the cache                                                                  |
-| `SMPL_FRM_IMAGE_FILL_MODE`              | "blur"                             | How to fill aspect ratio gaps: `border` (replicate edges), `blur` (blurred background), or `zoom_to_fill` (zoom to fill)  |
-| `SMPL_FRM_IMAGE_ZOOM_EFFECT`            | True                               | Enables slow zoom animation on images from center (1.0x to 1.2x scale over display duration)                              |
-| `SMPL_FRM_IMAGE_TRANSITION_TYPE`        | "random"                           | Image transition effect: `fade`, `slide-left`, `slide-right`, `zoom`, `none`, or `random`                                 |
-
-### Plugin Environment Variables
-
-Plugin env vars use the prefix `SMPL_FRM_PLUGINS_{PLUGIN_NAME}_`. These override plugin DB settings on every startup.
-
-#### Spotify
-
-| Name                                     | Default | Description                                                                                                               |
-|------------------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------|
-| `SMPL_FRM_PLUGINS_SPOTIFY_CLIENT_ID`     | None    | See: https://spotipy.readthedocs.io/en/latest/#getting-started                                                            |
-| `SMPL_FRM_PLUGINS_SPOTIFY_CLIENT_SECRET` | None    | See ^ - Ensure your Redirect URI matches Http://`SMPL_FRM_HOST`:`SMPL_FRM_EXTERNAL_PORT`/api/v1/plugins/spotify/callback  |
-
-#### Weather
-
-| Name                                      | Default              | Description                                                                                          |
-|-------------------------------------------|----------------------|------------------------------------------------------------------------------------------------------|
-| `SMPL_FRM_PLUGINS_WEATHER_COORDS`         | "63.1786,-147.4661"  | Lat,Long for weather. [Weather data by Open-Meteo.com](https://open-meteo.com)                       |
-| `SMPL_FRM_PLUGINS_WEATHER_TEMP_UNIT`      | "F"                  | `F` for Fahrenheit, `C` for Celsius                                                                  |
-| `SMPL_FRM_PLUGINS_WEATHER_PRECIP_UNIT`    | "in"                 | `in` for inches, `mm` for millimeters                                                                |
-| `SMPL_FRM_PLUGINS_WEATHER_WINDSPEED_UNIT` | "mph"                | `kmh` kilos per hour, `kn` knots, `ms` meters per second, `mph` miles per hour                       |
+See the [Environment Variables](https://github.com/rickyphewitt/smplFrm/wiki/Environment-Variables) wiki page for the full reference of all application, infrastructure, and plugin environment variables.

--- a/docker/compose/compose.yaml
+++ b/docker/compose/compose.yaml
@@ -10,37 +10,20 @@ services:
         volumes:
             - ../../library:/app/library
             - db:/app/src/smplfrm/db
-        networks:
-          - smpl_frm_net
-    smpl_frm_celery:
-        command: [ "make", "start-celery"]
-        build:
-            context: ../../
-            dockerfile: ./docker/images/Dockerfile
-        env_file:
-          - config.env
-        volumes:
-            - ../../library:/app/library
-            - db:/app/src/smplfrm/db
-        networks:
-          - smpl_frm_net
-    smpl_frm_celery_beat:
-        command: [ "make", "start-celery-beat"]
-        build:
-            context: ../../
-            dockerfile: ./docker/images/Dockerfile
-        env_file:
-          - config.env
-        volumes:
-            - ../../library:/app/library
-            - db:/app/src/smplfrm/db
+        depends_on:
+          - cache
         networks:
           - smpl_frm_net
 
     cache:
-      extends:
-        file: services.yaml
-        service: cache
+        image: redis:7.4.1-alpine
+        restart: always
+        ports:
+          - "6379:6379"
+        volumes:
+          - cache:/data
+        networks:
+          - smpl_frm_net
 
 networks:
   smpl_frm_net:
@@ -50,7 +33,3 @@ volumes:
     driver: local
   db:
     driver: local
-    driver_opts:
-      type: none
-      device: /home/ricky/dev/smplFrm/docker/data
-      o: bind

--- a/docker/images/Dockerfile
+++ b/docker/images/Dockerfile
@@ -10,9 +10,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-
-COPY ../.. /app
+COPY . /app
 
 RUN make packages
 
-CMD ["make", "run"]
+COPY docker/images/entrypoint.sh /app/entrypoint.sh
+
+EXPOSE 8321
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/images/entrypoint.sh
+++ b/docker/images/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+cd /app/src/smplfrm
+
+# Run migrations and collect static files
+python3.14 manage.py migrate
+python3.14 manage.py collectstatic --noinput
+
+# Start celery worker in background
+python3.14 -m celery -A smplfrm worker -E -l info &
+
+# Start celery beat in background
+python3.14 -m celery -A smplfrm beat -l info &
+
+# Start Django server in foreground
+exec python3.14 manage.py runserver 0.0.0.0:8321

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,0 +1,114 @@
+# Docker
+
+smplFrm is distributed as a single Docker image that bundles the Django web server, Celery worker, and Celery beat scheduler. Only Redis is required as an external service.
+
+## Quick Start
+
+```yaml
+services:
+    smpl_frm:
+        image: dke39vsh3gghs/smplfrm:latest
+        ports:
+          - "8321:8321"
+        environment:
+            - SMPL_FRM_LIBRARY_DIRS=/app/library
+            - REDIS_HOST=cache
+            - PYTHONUNBUFFERED=1
+        volumes:
+            - /path/to/your/photos:/app/library
+        depends_on:
+          - cache
+
+    cache:
+        image: redis:7.4.1-alpine
+        restart: always
+```
+
+```bash
+docker compose up -d
+```
+
+Browse to `http://localhost:8321`.
+
+## Architecture
+
+The container runs three processes via an entrypoint script:
+
+1. **Celery worker** — processes background tasks (image caching, library scanning)
+2. **Celery beat** — schedules periodic tasks
+3. **Django server** — serves the web UI and REST API (foreground process)
+
+On startup the entrypoint also runs database migrations and collects static files.
+
+## Volume Mounts
+
+| Mount | Container Path | Description |
+|-------|---------------|-------------|
+| Photo library | `/app/library` | Your photo directories. Set `SMPL_FRM_LIBRARY_DIRS` to match. |
+| Database | `/app/src/smplfrm/db` | SQLite database for persistent config, tasks, and plugin state. Optional — a new DB is created if not mounted. |
+
+### Example with DB persistence
+
+```yaml
+services:
+    smpl_frm:
+        image: dke39vsh3gghs/smplfrm:latest
+        ports:
+          - "8321:8321"
+        environment:
+            - SMPL_FRM_LIBRARY_DIRS=/app/library
+            - REDIS_HOST=cache
+            - PYTHONUNBUFFERED=1
+        volumes:
+            - /path/to/your/photos:/app/library
+            - smplfrm-db:/app/src/smplfrm/db
+        depends_on:
+          - cache
+
+    cache:
+        image: redis:7.4.1-alpine
+        restart: always
+
+volumes:
+  smplfrm-db:
+```
+
+## Environment Variables
+
+See [Environment Variables](Environment-Variables) for the full reference of all application, infrastructure, and plugin environment variables.
+
+## Docker Hub
+
+**Repo:** https://hub.docker.com/r/dke39vsh3gghs/smplfrm
+
+| Tag | Description |
+|-----|-------------|
+| `vX.X.X` | Official releases. Recommended for production. |
+| `latest` | Most recent code on `main`. Useful for development and testing. |
+| `<commit-hash>` | Pinned to a specific commit on `main`. |
+
+## Updating
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Migrations run automatically on container startup.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Container exits immediately | Check logs: `docker compose logs smpl_frm` |
+| Redis connection refused | Ensure `REDIS_HOST` matches the Redis service name and `depends_on` is set. |
+| Photos not showing | Verify the volume mount path and `SMPL_FRM_LIBRARY_DIRS` match. Check supported formats with `SMPL_FRM_IMAGE_FORMATS`. |
+| Port already in use | Stop any local dev server or change the host port mapping. |
+
+## Building from Source
+
+```bash
+docker build -f docker/images/Dockerfile -t smplfrm .
+```
+
+The build context is the repository root. The Dockerfile is at `docker/images/Dockerfile`.

--- a/docs/Environment-Variables.md
+++ b/docs/Environment-Variables.md
@@ -1,0 +1,51 @@
+# Environment Variables
+
+Environment variables seed the initial configuration on first startup. After that, most settings can be managed through the [Settings](Settings) modal.
+
+## Application
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `SMPL_FRM_LIBRARY_DIRS` | `<settings.py-dir>/../../library` | Comma-separated list of photo directory paths. |
+| `SMPL_FRM_IMAGE_FORMATS` | `jpg,png` | Comma-separated list of image file extensions to scan. |
+| `SMPL_FRM_IMAGE_REFRESH_INTERVAL` | `30000` | How long to display each image (milliseconds). |
+| `SMPL_FRM_IMAGE_TRANSITION_INTERVAL` | `10000` | Transition duration between images (milliseconds). |
+| `SMPL_FRM_EXTERNAL_PORT` | `8321` | Set when the external port differs from the server port. |
+| `SMPL_FRM_HOST` | `localhost` | Hostname for the application. |
+| `SMPL_FRM_PROTOCOL` | `http://` | Set to `https://` for SSL. |
+| `SMPL_FRM_DISPLAY_DATE` | `True` | Show photo date overlay. |
+| `SMPL_FRM_FORCE_DATE_FROM_PATH` | `True` | Use file path (`YYYY/MM`) for photo date instead of EXIF. |
+| `SMPL_FRM_DISPLAY_CLOCK` | `True` | Show current date and time. |
+| `SMPL_FRM_DISPLAY_WEATHER` | `True` | Display the weather. |
+| `SMPL_FRM_TIMEZONE` | `America/Los_Angeles` | IANA timezone identifier. |
+| `SMPL_FRM_IMAGE_CACHE_TIMEOUT` | `300` | Seconds until a cached image is evicted. |
+| `SMPL_FRM_IMAGE_FILL_MODE` | `blur` | Aspect ratio fill: `blur`, `border`, or `zoom_to_fill`. |
+| `SMPL_FRM_IMAGE_ZOOM_EFFECT` | `True` | Enable slow zoom animation on images. |
+| `SMPL_FRM_IMAGE_TRANSITION_TYPE` | `random` | Transition effect: `fade`, `slide-left`, `slide-right`, `zoom`, `none`, or `random`. |
+
+## Infrastructure
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `REDIS_HOST` | `localhost` | Hostname of the Redis service. In Docker, set to the compose service name (e.g. `cache`). |
+| `PYTHONUNBUFFERED` | — | Set to `1` for real-time log output. Recommended for Docker. |
+
+## Plugins
+
+Plugin env vars use the prefix `SMPL_FRM_PLUGINS_{PLUGIN_NAME}_`. These override plugin DB settings on every startup.
+
+### Spotify
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `SMPL_FRM_PLUGINS_SPOTIFY_CLIENT_ID` | — | Spotify API client ID. See [Spotipy docs](https://spotipy.readthedocs.io/en/latest/#getting-started). |
+| `SMPL_FRM_PLUGINS_SPOTIFY_CLIENT_SECRET` | — | Spotify API client secret. Redirect URI must match `{SMPL_FRM_PROTOCOL}{SMPL_FRM_HOST}:{SMPL_FRM_EXTERNAL_PORT}/api/v1/plugins/spotify/callback`. |
+
+### Weather
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `SMPL_FRM_PLUGINS_WEATHER_COORDS` | `63.1786,-147.4661` | Lat,Long for weather location. [Weather data by Open-Meteo.com](https://open-meteo.com) |
+| `SMPL_FRM_PLUGINS_WEATHER_TEMP_UNIT` | `F` | `F` for Fahrenheit, `C` for Celsius. |
+| `SMPL_FRM_PLUGINS_WEATHER_PRECIP_UNIT` | `in` | `in` for inches, `mm` for millimeters. |
+| `SMPL_FRM_PLUGINS_WEATHER_WINDSPEED_UNIT` | `mph` | `kmh`, `kn`, `ms`, or `mph`. |

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -2,4 +2,6 @@ Welcome to the smplFrm wiki!
 
 ## Pages
 
+- [Docker](Docker)
+- [Environment Variables](Environment-Variables)
 - [Settings](Settings)


### PR DESCRIPTION
## Summary
Consolidates the Docker setup from 4 services (web, celery, celery-beat, cache) into 2 (app + Redis) and updates all documentation to match.

Closes #103

## Changes

### Docker consolidation
- **`docker/images/entrypoint.sh`** (new): starts celery worker + celery beat as background processes, Django server as foreground. Runs migrations and collectstatic on startup.
- **`docker/images/Dockerfile`**: fixed `COPY` context, added `EXPOSE 8321`, switched from `CMD` to `ENTRYPOINT`.
- **`docker/compose/compose.yaml`**: reduced from 4 services to 2 (app + cache). Inlined Redis, added `depends_on`.
- **`docker/compose/services.yaml`**: kept as-is for native dev (`make docker-services`).

### Documentation
- **README**: replaced inaccurate `docker build`/`docker run` commands with description of single-container architecture. Updated compose example with Redis and `REDIS_HOST`. Fixed `SMPL_FRM_ASSET_DIRECTORIES` → `SMPL_FRM_LIBRARY_DIRS`. Linked to wiki.
- **`docs/Docker.md`** (new wiki page): quick start, architecture, volume mounts, all env vars, Docker Hub tags, updating, troubleshooting, building from source.
- **`docs/Home.md`**: added Docker wiki link.

## Testing
- Built and ran locally with `docker compose up -d --build`
- Verified all 3 processes start (migrations, celery beat, celery worker, Django server)
- Confirmed web UI returns 200 on `localhost:8321`