### PR TITLE
fix(weather): validate coords and return 400 instead of 500

### DIFF
--- a/src/smplfrm/smplfrm/plugins/weather/views.py
+++ b/src/smplfrm/smplfrm/plugins/weather/views.py
@@ -10,7 +10,15 @@ class WeatherView(viewsets.ViewSet):
 
     def list(self, *args, **kwargs):
         plugin = WeatherPlugin()
+        try:
+            data = plugin.get_for_display()
+        except ValueError as e:
+            return HttpResponse(
+                json.dumps({"error": str(e)}),
+                content_type="application/json",
+                status=400,
+            )
         return HttpResponse(
-            json.dumps(plugin.get_for_display()),
+            json.dumps(data),
             content_type="application/json",
         )

--- a/src/smplfrm/smplfrm/plugins/weather/weather.py
+++ b/src/smplfrm/smplfrm/plugins/weather/weather.py
@@ -78,9 +78,14 @@ class WeatherPlugin(BasePlugin):
         """Load weather settings from DB."""
         super().configure()
         s = self.get_plugin_settings()
-        coords = s.get("coords", "63.1786,-147.4661").split(",")
-        self.lat = coords[0].strip()
-        self.long = coords[1].strip()
+        coords = s.get("coords", "63.1786,-147.4661")
+        if not coords:
+            raise ValueError("Coordinates are required")
+        parts = coords.split(",")
+        if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
+            raise ValueError("Coordinates must be in 'lat,long' format")
+        self.lat = parts[0].strip()
+        self.long = parts[1].strip()
         self.tz = s.get("timezone", "America/Los_Angeles")
         self._determine_temp_unit(s.get("temp_unit", "F"))
         self.precip_unit = self._determine_precip_unit(s.get("precip_unit", "in"))

--- a/src/smplfrm/smplfrm/tests/plugins/weather/test_weather_empty_coords.py
+++ b/src/smplfrm/smplfrm/tests/plugins/weather/test_weather_empty_coords.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework import status
+from unittest.mock import patch
+
+from smplfrm.plugins.weather.weather import WeatherPlugin
+
+
+class TestWeatherEmptyCoords(TestCase):
+    """Regression tests for empty/invalid coordinates (#163)."""
+
+    @patch("smplfrm.plugins.weather.weather.BasePlugin.get_plugin_settings")
+    def test_configure_with_empty_coords_raises(self, mock_settings):
+        mock_settings.return_value = {"coords": ""}
+        plugin = WeatherPlugin()
+        with self.assertRaises(ValueError):
+            plugin.configure()
+
+    @patch("smplfrm.plugins.weather.weather.BasePlugin.get_plugin_settings")
+    def test_configure_with_single_value_raises(self, mock_settings):
+        mock_settings.return_value = {"coords": "63.1786"}
+        plugin = WeatherPlugin()
+        with self.assertRaises(ValueError):
+            plugin.configure()
+
+    @patch("smplfrm.plugins.weather.views.WeatherPlugin")
+    def test_view_returns_400_when_coords_invalid(self, mock_plugin_cls):
+        mock_plugin_cls.return_value.get_for_display.side_effect = ValueError(
+            "Invalid coordinates"
+        )
+        client = APIClient()
+        response = client.get("/api/v1/plugins/weather")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary
Empty or invalid coordinates in the Weather plugin caused a 500 server error (`IndexError` on `split`). Now validates coords in `configure()` and returns 400 from the view.

Closes #163

## Changes
- **`weather.py`**: `configure()` validates coords are non-empty and contain exactly two comma-separated values, raises `ValueError` otherwise
- **`views.py`**: catches `ValueError` from `get_for_display()` and returns 400 with error message

## Tests (`test_weather_empty_coords.py`)
- Empty coords raises `ValueError`
- Single value (no comma) raises `ValueError`
- View returns 400 when coords are invalid