### PR TITLE
feat(ui): display version on About page (#175)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ coverage/
 
 # kiro
 .kiro/settings/lsp.json
+
+# Build artifacts
+VERSION

--- a/.kiro/hooks/lint-and-format-on-save.kiro.hook
+++ b/.kiro/hooks/lint-and-format-on-save.kiro.hook
@@ -1,5 +1,5 @@
 {
-  "enabled": true,
+  "enabled": false,
   "name": "Lint and Format on Save",
   "description": "Automatically lint and format code when files are saved following project standards",
   "version": "1",

--- a/.kiro/steering/development-standards.md
+++ b/.kiro/steering/development-standards.md
@@ -23,6 +23,11 @@ inclusion: always
 - Keep functions small and focused on single responsibilities
 - Implement proper error handling and logging
 
+## Formatting and Linting
+- **DO NOT** run formatters or linters on file save — formatting is handled by a pre-commit git hook
+- **DO NOT** create or enable Kiro hooks that auto-format or auto-lint on save
+- The `.pre-commit-config.yaml` defines all formatting and linting rules; they run automatically at commit time
+
 ## File Management
 - Maintain clean directory structures
 - Use consistent naming conventions across the project

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,6 @@ pre-commit: packages
 
 ignore-format-commit:
 	git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+version:
+	. ./local_venv/bin/activate; ./scripts/generate_version.sh

--- a/docker/images/entrypoint.sh
+++ b/docker/images/entrypoint.sh
@@ -3,6 +3,9 @@ set -e
 
 cd /app
 
+# Generate version file from git info
+./scripts/generate_version.sh
+
 # Start celery worker in background
 make start-celery &
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -137,3 +137,7 @@ Each row includes a delete button (×) that deletes the task. If the task is cur
 Only one task of each type can be pending or running at a time. Attempting to start a duplicate will show an error in the toast.
 
 Tasks that were created more than 7 days ago will be deleted.
+
+## About
+
+The About tab displays general information about smplFrm and the current application version.

--- a/scripts/generate_version.sh
+++ b/scripts/generate_version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Resolves git tag or short hash and writes to VERSION file.
+# Usage: ./scripts/generate_version.sh [output_path]
+# Default output_path: VERSION (project root)
+
+OUTPUT="${1:-VERSION}"
+
+if ! command -v git &>/dev/null || ! git rev-parse --git-dir &>/dev/null 2>&1; then
+    echo "unknown" > "$OUTPUT"
+    exit 0
+fi
+
+TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]' | head -n 1)
+
+if [ -n "$TAG" ]; then
+    echo "$TAG" > "$OUTPUT"
+else
+    echo "$(git rev-parse --short HEAD)" > "$OUTPUT"
+fi

--- a/src/smplfrm/smplfrm/services/version_service.py
+++ b/src/smplfrm/smplfrm/services/version_service.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from django.conf import settings
+
+FALLBACK_VERSION = "unknown"
+
+
+class VersionService:
+    """Reads the application version from the VERSION file."""
+
+    def __init__(self, version_file: Path = None):
+        self._version_file = version_file or settings.PROJECT_ROOT / "VERSION"
+
+    def get_version(self) -> str:
+        """Return the version string from the VERSION file.
+
+        Returns FALLBACK_VERSION if the file is missing or unreadable.
+        """
+        try:
+            return self._version_file.read_text().strip()
+        except (FileNotFoundError, PermissionError, OSError):
+            return FALLBACK_VERSION

--- a/src/smplfrm/smplfrm/settings.py
+++ b/src/smplfrm/smplfrm/settings.py
@@ -19,6 +19,9 @@ from celery.schedules import crontab
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Project root (repository root) for files like VERSION that live outside src/
+PROJECT_ROOT = BASE_DIR.parent.parent
+
 # app specific env vars
 default_library = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../../../", "library")

--- a/src/smplfrm/smplfrm/templates/index.html
+++ b/src/smplfrm/smplfrm/templates/index.html
@@ -268,11 +268,35 @@
         
         <div class="tab-content" id="tab-about">
             <div class="settings-section">
-                <h3>About smplFrm</h3>
-                <p style="color: #aaa; line-height: 1.6;">Digital photoframe for displaying photos on any device that has a web browser.</p>
-                <p style="color: #aaa; line-height: 1.6; margin-top: 15px;">
-                    <a href="https://github.com/rickyphewitt/smplFrm" target="_blank" style="color: #667eea; text-decoration: none;">View on GitHub</a>
+                <h3>smplFrm</h3>
+                <p style="color: #aaa; line-height: 1.6; margin-bottom: 20px;">
+                    Digital photo frame for displaying photos on any device with a web browser.
                 </p>
+                <div class="setting-item">
+                    <label>Version</label>
+                    <span>
+                        {% if version and version != "unknown" %}
+                            {% if version|first == "v" %}
+                                <a href="https://github.com/rickyphewitt/smplFrm/releases/tag/{{ version }}" target="_blank" rel="noopener noreferrer" style="color: #667eea; text-decoration: none;">{{ version }}</a>
+                            {% else %}
+                                <a href="https://github.com/rickyphewitt/smplFrm/commit/{{ version }}" target="_blank" rel="noopener noreferrer" style="color: #667eea; text-decoration: none;">{{ version }}</a>
+                            {% endif %}
+                        {% else %}
+                            <span style="color: #aaa;">unknown</span>
+                        {% endif %}
+                    </span>
+                </div>
+            </div>
+            <div class="settings-section">
+                <h3>Links</h3>
+                <div class="setting-item">
+                    <label>GitHub</label>
+                    <a href="https://github.com/rickyphewitt/smplFrm" target="_blank" rel="noopener noreferrer" style="color: #667eea; text-decoration: none;">rickyphewitt/smplFrm →</a>
+                </div>
+                <div class="setting-item">
+                    <label>Wiki</label>
+                    <a href="https://github.com/rickyphewitt/smplFrm/wiki" target="_blank" rel="noopener noreferrer" style="color: #667eea; text-decoration: none;">smplFrm Wiki →</a>
+                </div>
             </div>
         </div>
         

--- a/src/smplfrm/smplfrm/tests/services/test_version_service.py
+++ b/src/smplfrm/smplfrm/tests/services/test_version_service.py
@@ -1,0 +1,82 @@
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+from django.test import TestCase
+
+from smplfrm.services.version_service import FALLBACK_VERSION, VersionService
+
+
+class TestVersionService(TestCase):
+    """Tests for VersionService file reading and fallback behavior."""
+
+    def test_read_tag_version(self):
+        """Reading a file containing a tag version returns the tag string."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("v1.0.0")
+            f.flush()
+            path = Path(f.name)
+        try:
+            service = VersionService(version_file=path)
+            self.assertEqual(service.get_version(), "v1.0.0")
+        finally:
+            path.unlink()
+
+    def test_read_hash_version(self):
+        """Reading a file containing a commit hash returns the hash string."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("abc1234")
+            f.flush()
+            path = Path(f.name)
+        try:
+            service = VersionService(version_file=path)
+            self.assertEqual(service.get_version(), "abc1234")
+        finally:
+            path.unlink()
+
+    def test_fallback_when_file_missing(self):
+        """Returns fallback 'unknown' when the VERSION file does not exist."""
+        missing_path = Path(tempfile.gettempdir()) / "nonexistent_version_file"
+        service = VersionService(version_file=missing_path)
+        self.assertEqual(service.get_version(), FALLBACK_VERSION)
+
+    def test_fallback_when_file_unreadable(self):
+        """Returns fallback 'unknown' when the VERSION file has no read permission."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("v2.0.0")
+            f.flush()
+            path = Path(f.name)
+        try:
+            # Remove all permissions
+            os.chmod(path, 0o000)
+            service = VersionService(version_file=path)
+            self.assertEqual(service.get_version(), FALLBACK_VERSION)
+        finally:
+            # Restore permissions so cleanup can delete the file
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+            path.unlink()
+
+    def test_whitespace_is_stripped(self):
+        """Leading and trailing whitespace is stripped from the version string."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("  v1.2.3\n  ")
+            f.flush()
+            path = Path(f.name)
+        try:
+            service = VersionService(version_file=path)
+            self.assertEqual(service.get_version(), "v1.2.3")
+        finally:
+            path.unlink()
+
+    def test_empty_file_returns_empty_string(self):
+        """An empty VERSION file returns an empty string (not fallback)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("")
+            f.flush()
+            path = Path(f.name)
+        try:
+            service = VersionService(version_file=path)
+            self.assertEqual(service.get_version(), "")
+        finally:
+            path.unlink()

--- a/src/smplfrm/smplfrm/tests/views/test_index_view.py
+++ b/src/smplfrm/smplfrm/tests/views/test_index_view.py
@@ -1,0 +1,184 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from smplfrm.models import Config
+
+
+class TestIndexViewVersionContext(TestCase):
+    """Tests that IndexView passes version from VersionService to template context."""
+
+    def setUp(self):
+        """Ensure an active config exists so IndexView renders without error."""
+        Config.objects.all().delete()
+        Config.objects.create(
+            name="smplFrm Default",
+            is_active=True,
+            display_date=True,
+            display_clock=True,
+            image_refresh_interval=30000,
+            image_transition_type="fade",
+        )
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_version_key_present_in_context(self, mock_get_version):
+        """Template context includes the 'version' key."""
+        mock_get_version.return_value = "v1.0.0"
+        response = self.client.get("/")
+        self.assertIn("version", response.context)
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_version_value_comes_from_version_service(self, mock_get_version):
+        """The version context value is the return value of VersionService.get_version()."""
+        mock_get_version.return_value = "test-sentinel"
+        response = self.client.get("/")
+        self.assertEqual(response.context["version"], "test-sentinel")
+        mock_get_version.assert_called_once()
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_version_with_tag(self, mock_get_version):
+        """When VersionService returns a tag version, context reflects it."""
+        mock_get_version.return_value = "v2.3.1"
+        response = self.client.get("/")
+        self.assertEqual(response.context["version"], "v2.3.1")
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_version_with_hash(self, mock_get_version):
+        """When VersionService returns a commit hash, context reflects it."""
+        mock_get_version.return_value = "abc1234"
+        response = self.client.get("/")
+        self.assertEqual(response.context["version"], "abc1234")
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_version_unknown(self, mock_get_version):
+        """When VersionService returns 'unknown', context reflects it."""
+        mock_get_version.return_value = "unknown"
+        response = self.client.get("/")
+        self.assertEqual(response.context["version"], "unknown")
+
+
+class TestIndexViewVersionTemplateRendering(TestCase):
+    """Tests that the About tab renders version with correct links based on version type."""
+
+    def setUp(self):
+        """Ensure an active config exists so IndexView renders without error."""
+        Config.objects.all().delete()
+        Config.objects.create(
+            name="smplFrm Default",
+            is_active=True,
+            display_date=True,
+            display_clock=True,
+            image_refresh_interval=30000,
+            image_transition_type="fade",
+        )
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_tag_version_renders_as_release_link(self, mock_get_version):
+        """A tag version (starts with 'v') renders as a GitHub release link."""
+        mock_get_version.return_value = "v1.0.0"
+        response = self.client.get("/")
+        content = response.content.decode()
+        self.assertIn(
+            'href="https://github.com/rickyphewitt/smplFrm/releases/tag/v1.0.0"',
+            content,
+        )
+        self.assertIn("v1.0.0", content)
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_hash_version_renders_as_commit_link(self, mock_get_version):
+        """A hash version renders as a GitHub commit link."""
+        mock_get_version.return_value = "abc1234"
+        response = self.client.get("/")
+        content = response.content.decode()
+        self.assertIn(
+            'href="https://github.com/rickyphewitt/smplFrm/commit/abc1234"',
+            content,
+        )
+        self.assertIn("abc1234", content)
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_unknown_version_renders_as_plain_text(self, mock_get_version):
+        """The 'unknown' version renders as plain text with no version link."""
+        mock_get_version.return_value = "unknown"
+        response = self.client.get("/")
+        content = response.content.decode()
+        self.assertIn("unknown", content)
+        self.assertNotIn("releases/tag/unknown", content)
+        self.assertNotIn("commit/unknown", content)
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_tag_version_link_opens_in_new_tab(self, mock_get_version):
+        """Release links have target='_blank' and rel='noopener noreferrer'."""
+        mock_get_version.return_value = "v2.0.0"
+        response = self.client.get("/")
+        content = response.content.decode()
+        self.assertIn('target="_blank"', content)
+        self.assertIn('rel="noopener noreferrer"', content)
+        self.assertIn(
+            'href="https://github.com/rickyphewitt/smplFrm/releases/tag/v2.0.0"',
+            content,
+        )
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_hash_version_link_opens_in_new_tab(self, mock_get_version):
+        """Commit links have target='_blank' and rel='noopener noreferrer'."""
+        mock_get_version.return_value = "def5678"
+        response = self.client.get("/")
+        content = response.content.decode()
+        self.assertIn('target="_blank"', content)
+        self.assertIn('rel="noopener noreferrer"', content)
+        self.assertIn(
+            'href="https://github.com/rickyphewitt/smplFrm/commit/def5678"',
+            content,
+        )
+
+
+class TestIndexViewAboutPageLinks(TestCase):
+    """Tests that the About tab renders static links for GitHub and Wiki."""
+
+    def setUp(self):
+        """Ensure an active config exists so IndexView renders without error."""
+        Config.objects.all().delete()
+        Config.objects.create(
+            name="smplFrm Default",
+            is_active=True,
+            display_date=True,
+            display_clock=True,
+            image_refresh_interval=30000,
+            image_transition_type="fade",
+        )
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_github_repo_link_present(self, mock_get_version):
+        """The About tab includes a link to the GitHub repository."""
+        mock_get_version.return_value = "v1.0.0"
+        response = self.client.get("/")
+        content = response.content.decode()
+        self.assertIn('href="https://github.com/rickyphewitt/smplFrm"', content)
+        self.assertIn("rickyphewitt/smplFrm", content)
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_wiki_link_present(self, mock_get_version):
+        """The About tab includes a link to the GitHub wiki."""
+        mock_get_version.return_value = "v1.0.0"
+        response = self.client.get("/")
+        content = response.content.decode()
+        self.assertIn('href="https://github.com/rickyphewitt/smplFrm/wiki"', content)
+        self.assertIn("smplFrm Wiki", content)
+
+    @patch("smplfrm.services.version_service.VersionService.get_version")
+    def test_static_links_open_in_new_tab(self, mock_get_version):
+        """GitHub and Wiki links open in a new tab with noopener noreferrer."""
+        mock_get_version.return_value = "v1.0.0"
+        response = self.client.get("/")
+        content = response.content.decode()
+        # Find the GitHub link and verify attributes
+        github_idx = content.index("rickyphewitt/smplFrm →")
+        github_section = content[max(0, github_idx - 200) : github_idx]
+        self.assertIn('target="_blank"', github_section)
+        self.assertIn('rel="noopener noreferrer"', github_section)
+        # Find the Wiki link and verify attributes
+        wiki_idx = content.index("smplFrm Wiki")
+        wiki_section = content[max(0, wiki_idx - 200) : wiki_idx]
+        self.assertIn('target="_blank"', wiki_section)
+        self.assertIn('rel="noopener noreferrer"', wiki_section)

--- a/src/smplfrm/smplfrm/views/index_view.py
+++ b/src/smplfrm/smplfrm/views/index_view.py
@@ -1,5 +1,6 @@
 from django.views.generic import TemplateView
 from smplfrm.services.config_service import ConfigService
+from smplfrm.services.version_service import VersionService
 
 from smplfrm.settings import (
     SMPL_FRM_EXTERNAL_PORT,
@@ -29,6 +30,7 @@ class IndexView(TemplateView):
             "image_transition_type": config.image_transition_type,
             "plugins": config.plugins,
             "timezones": sorted(available_timezones()),
+            "version": VersionService().get_version(),
         }
 
         return context


### PR DESCRIPTION
Fixes #175 
## Summary

Adds version display to the About tab in the settings modal. The version is resolved at build time from git information (tag or short hash), written to a `VERSION` file, and read at runtime with no git dependency.

### Changes

- **VersionService** — reads `VERSION` file with fallback to `unknown` when missing/unreadable
- **IndexView** — passes version string to template context
- **About tab redesign** — key-value row layout with version, GitHub repo link, and Wiki link
- **Build script** — `scripts/generate_version.sh` resolves git tag or short hash
- **Makefile** — `make version` target for local development
- **Docker** — `entrypoint.sh` generates version at container start
- **Docs** — updated `docs/Settings.md` with About section

### Version display behavior

| Version type | Behavior |
|---|---|
| Tagged release (e.g. `v1.0.0`) | Links to GitHub release page |
| Commit hash (e.g. `abc1234`) | Links to GitHub commit page |
| `unknown` | Plain text, no link |

### Tests

- 6 VersionService unit tests (tag, hash, missing file, unreadable, whitespace, empty)
- 5 IndexView context tests
- 5 version link rendering tests
- 3 static link tests (GitHub repo, Wiki, new-tab attributes)