### PR TITLE
fix: validate image dimension query params (#174)

### DIFF
--- a/.kiro/steering/development-standards.md
+++ b/.kiro/steering/development-standards.md
@@ -6,6 +6,7 @@ inclusion: always
 # Development Standards
 
 ## Dependency Management
+- **NEVER install packages (pip install, npm install, etc.) without explicit user approval** — always ask first
 - Use latest stable versions of all libraries and dependencies
 - Leverage Context7 MCP server to verify compatibility before adding dependencies
 - Justify each new dependency with clear business or technical value
@@ -15,6 +16,7 @@ inclusion: always
 - Use lock files to ensure consistent installations across environments
 
 ## Code Quality Standards
+- When choosing default values or magic numbers, always document the rationale — don't blindly adopt values from issue descriptions without independent justification
 - Never create duplicate files with suffixes like `_fixed`, `_clean`, `_backup`, etc.
 - Work iteratively on existing files (hooks handle commits automatically)
 - Include relevant documentation links in code comments
@@ -56,6 +58,7 @@ inclusion: always
 ## Version Control Integration
 - Commit frequently with meaningful messages
 - Use feature branches for development — one branch per subtask (e.g. `feature/133-plugin-architecture`)
+- Always checkout a new branch before starting work on a bug or feature (e.g. `fix/174-image-dimension-bounds`)
 - Keep main branch deployable at all times
 - Tag releases appropriately
 - Use .gitignore to exclude generated files and secrets

--- a/src/smplfrm/smplfrm/services/image_manipulation_service.py
+++ b/src/smplfrm/smplfrm/services/image_manipulation_service.py
@@ -15,6 +15,30 @@ logger = logging.getLogger(__name__)
 class ImageManipulationService:
     """Service for image manipulation and display operations."""
 
+    MAX_IMAGE_DIMENSION = 4096
+
+    @staticmethod
+    def validate_dimensions(width_str, height_str):
+        """Validate width and height strings as positive integers within bounds.
+
+        Returns:
+            (width, height) tuple of ints on success.
+            (None, error_message) on failure.
+        """
+        for name, value in [("width", width_str), ("height", height_str)]:
+            try:
+                int_val = int(value)
+            except (ValueError, TypeError):
+                return (None, f"{name} must be a positive integer")
+            if int_val <= 0:
+                return (None, f"{name} must be a positive integer")
+            if int_val > ImageManipulationService.MAX_IMAGE_DIMENSION:
+                return (
+                    None,
+                    f"{name} exceeds maximum allowed value of {ImageManipulationService.MAX_IMAGE_DIMENSION}",
+                )
+        return (int(width_str), int(height_str))
+
     def display(
         self, image: Image, window_height: int = 100, window_width: int = 100
     ) -> np.ndarray:

--- a/src/smplfrm/smplfrm/tasks/tasks.py
+++ b/src/smplfrm/smplfrm/tasks/tasks.py
@@ -47,6 +47,11 @@ def cache_images(images_ext_ids: list, height: str, width: str):
     if not images_ext_ids or not height or not width:
         return
 
+    result = ImageManipulationService.validate_dimensions(str(width), str(height))
+    if result[0] is None:
+        logger.warning("cache_images called with invalid dimensions: %s", result[1])
+        return
+
     cache_service = CacheService()
     image_manipulation = ImageManipulationService()
     image_service = ImageService()

--- a/src/smplfrm/smplfrm/tests/services/test_image_manipulation_service.py
+++ b/src/smplfrm/smplfrm/tests/services/test_image_manipulation_service.py
@@ -323,3 +323,33 @@ class TestImageManipulationService(TestCase):
         # Should fall back to border mode
         self.assertEqual(img.shape[0], window_h)
         self.assertEqual(img.shape[1], window_w)
+
+
+import pytest
+
+VALID_BOUNDARY_VALUES = [1, 2, 100, 2048, 4095, 4096]
+
+
+class TestValidateDimensionsPreservation:
+    """Test suite for validate_dimensions with valid inputs."""
+
+    @pytest.mark.parametrize("width", VALID_BOUNDARY_VALUES)
+    @pytest.mark.parametrize("height", VALID_BOUNDARY_VALUES)
+    def test_valid_dimensions_return_tuple(self, width, height):
+        """Test that valid dimensions return the correct (width, height) tuple."""
+        result = ImageManipulationService.validate_dimensions(str(width), str(height))
+        assert result == (width, height)
+
+    @pytest.mark.parametrize(
+        "width_str,height_str,expected",
+        [
+            ("100", "100", (100, 100)),
+            ("1", "1", (1, 1)),
+            ("4096", "4096", (4096, 4096)),
+            ("800", "600", (800, 600)),
+        ],
+    )
+    def test_common_dimension_pairs(self, width_str, height_str, expected):
+        """Test that common dimension pairs are accepted and returned correctly."""
+        result = ImageManipulationService.validate_dimensions(width_str, height_str)
+        assert result == expected

--- a/src/smplfrm/smplfrm/tests/views/test_image_api.py
+++ b/src/smplfrm/smplfrm/tests/views/test_image_api.py
@@ -19,3 +19,96 @@ class TestImageAPI(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("view_count", response.data)
         self.assertEqual(response.data["view_count"], 0)
+
+
+from smplfrm.services import ImageService, LibraryService
+
+
+class TestImageDimensionBoundsExploration(TestCase):
+    """Test suite for invalid dimension parameter handling."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.image = Image.objects.create(
+            name="test", file_path="/tmp/", file_name="test.jpg"
+        )
+
+    def test_display_image_non_numeric_width_returns_400(self):
+        """Test that non-numeric width returns 400."""
+        response = self.client.get(
+            f"/api/v1/images/{self.image.external_id}/display?width=abc&height=100"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_display_image_zero_width_returns_400(self):
+        """Test that zero width returns 400."""
+        response = self.client.get(
+            f"/api/v1/images/{self.image.external_id}/display?width=0&height=100"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_display_image_negative_width_returns_400(self):
+        """Test that negative width returns 400."""
+        response = self.client.get(
+            f"/api/v1/images/{self.image.external_id}/display?width=-50&height=100"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_display_image_exceeds_max_dimension_returns_400(self):
+        """Test that dimensions exceeding MAX_IMAGE_DIMENSION return 400."""
+        response = self.client.get(
+            f"/api/v1/images/{self.image.external_id}/display?width=99999&height=99999"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_next_image_non_numeric_width_returns_400(self):
+        """Test that non-numeric width on next_image returns 400."""
+        response = self.client.get("/api/v1/images/next?width=abc&height=100")
+        self.assertEqual(response.status_code, 400)
+
+
+class TestImageDimensionBoundsPreservation(TestCase):
+    """Test suite for valid dimension parameter handling."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.image_service = ImageService()
+        LibraryService().scan()
+        self.image = self.image_service.list()[0]
+        self.uri = "/api/v1/images"
+
+    def test_display_image_with_valid_dimensions_returns_200(self):
+        """Test that valid dimensions return 200 with image data."""
+        response = self.client.get(
+            f"{self.uri}/{self.image.external_id}/display?width=800&height=600"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-type"], "image/jpeg")
+        self.assertGreater(len(response.content), 0)
+
+    def test_display_image_default_dimensions_returns_200(self):
+        """Test that omitted dimensions default to 100x100 and return 200."""
+        response = self.client.get(f"{self.uri}/{self.image.external_id}/display")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-type"], "image/jpeg")
+        self.assertGreater(len(response.content), 0)
+
+    def test_display_image_file_not_found_returns_404(self):
+        """Test that a missing file on disk returns 404."""
+        missing_image = Image.objects.create(
+            name="missing", file_path="/does/not/exist/", file_name="gone.jpg"
+        )
+        response = self.client.get(
+            f"{self.uri}/{missing_image.external_id}/display?width=100&height=100"
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_next_image_with_valid_dimensions_returns_200(self):
+        """Test that next_image with valid dimensions returns 200."""
+        response = self.client.get(f"{self.uri}/next?width=800&height=600")
+        self.assertEqual(response.status_code, 200)
+
+    def test_next_image_default_dimensions_returns_200(self):
+        """Test that next_image with omitted dimensions returns 200."""
+        response = self.client.get(f"{self.uri}/next")
+        self.assertEqual(response.status_code, 200)

--- a/src/smplfrm/smplfrm/views/api/v1/images.py
+++ b/src/smplfrm/smplfrm/views/api/v1/images.py
@@ -62,6 +62,15 @@ class Images(viewsets.ModelViewSet):
         width = request.GET.get("width", DEFAULT_WIDTH)
         height = request.GET.get("height", DEFAULT_HEIGHT)
 
+        result = ImageManipulationService.validate_dimensions(width, height)
+        if result[0] is None:
+            return HttpResponse(
+                content_type="application/json",
+                content=f'{{"error": "{result[1]}"}}',
+                status=400,
+            )
+        validated_width, validated_height = result
+
         cache_key = self.cache_service.get_image_cache_key(
             image.external_id, height, width
         )
@@ -70,7 +79,7 @@ class Images(viewsets.ModelViewSet):
         if cached_image is None:
             try:
                 cached_image = self.image_manipulation.display(
-                    image, int(height), int(width)
+                    image, validated_height, validated_width
                 )
             except FileNotFoundError:
                 return HttpResponse(status=404)
@@ -100,6 +109,14 @@ class Images(viewsets.ModelViewSet):
 
         width = request.GET.get("width", DEFAULT_WIDTH)
         height = request.GET.get("height", DEFAULT_HEIGHT)
+
+        result = ImageManipulationService.validate_dimensions(width, height)
+        if result[0] is None:
+            return HttpResponse(
+                content_type="application/json",
+                content=f'{{"error": "{result[1]}"}}',
+                status=400,
+            )
 
         cache_image_list = [img.external_id for img in images]
         cache_images_task.delay(cache_image_list, height, width)


### PR DESCRIPTION
## Summary

Adds input validation for `width` and `height` query parameters on the `display_image` and `next_image` endpoints. Invalid values (non-numeric, zero, negative, or exceeding 4096) now return a 400 Bad Request with a descriptive JSON error instead of causing 500 errors or undefined behavior.

## Changes

- Added `MAX_IMAGE_DIMENSION = 4096` constant and `validate_dimensions()` static method to `ImageManipulationService`
- Added validation calls in `display_image` and `next_image` view actions
- Added defensive guard in `cache_images` Celery task (logs warning and returns early for invalid dimensions)

## Tests

- Bug condition exploration tests (5 tests) — confirm invalid dimensions return 400
- Preservation property tests (5 view-level + 40 unit-level) — confirm valid dimensions and defaults are unchanged
- Full suite: 243 passed, 0 failed

Closes #174