### PR TITLE
fix(settings): read SECRET_KEY from env var

### DIFF
--- a/.kiro/steering/testing-best-practices.md
+++ b/.kiro/steering/testing-best-practices.md
@@ -11,7 +11,31 @@ inclusion: always
 - Filter tests with grep/pattern matching for focused testing
 - Avoid running full test suites in automated contexts unless necessary
 
-## Common Test Commands
+## Project Test Commands
+```bash
+# Python — full suite
+make test
+
+# Python — quiet mode (preferred for AI agents)
+. ./local_venv/bin/activate; cd ./src/smplfrm; pytest -q --tb=short
+
+# Python — single file
+. ./local_venv/bin/activate; cd ./src/smplfrm; pytest smplfrm/tests/test_secret_key.py -q --tb=short
+
+# Python — filter by name
+. ./local_venv/bin/activate; cd ./src/smplfrm; pytest -k "test_specific" -q --tb=short
+
+# JavaScript — full suite
+make test-js
+
+# JavaScript — watch mode
+make test-js-watch
+
+# JavaScript — coverage
+make test-js-coverage
+```
+
+## Generic Test Commands
 ```bash
 # NPM/Yarn - Use silent mode
 npm test -- --silent

--- a/docker/compose/config.env
+++ b/docker/compose/config.env
@@ -21,6 +21,8 @@ SMPL_FRM_PLUGINS_WEATHER_PRECIP_UNIT = in
 SMPL_FRM_PLUGINS_WEATHER_WINDSPEED_UNIT = mph
 
 #Django
+# Generate a key: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+DJANGO_SECRET_KEY=change-me
 REDIS_HOST=cache
 
 #Python

--- a/docs/Environment-Variables.md
+++ b/docs/Environment-Variables.md
@@ -27,8 +27,15 @@ Environment variables seed the initial configuration on first startup. After tha
 
 | Name | Default | Description |
 |------|---------|-------------|
+| `DJANGO_SECRET_KEY` | insecure dev key | Django secret key used for cryptographic signing. Falls back to a dev-only insecure default when unset. **Set this in production.** |
 | `REDIS_HOST` | `localhost` | Hostname of the Redis service. In Docker, set to the compose service name (e.g. `cache`). |
 | `PYTHONUNBUFFERED` | — | Set to `1` for real-time log output. Recommended for Docker. |
+
+### Generating a secret key
+
+```bash
+python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+```
 
 ## Plugins
 

--- a/src/smplfrm/smplfrm/settings.py
+++ b/src/smplfrm/smplfrm/settings.py
@@ -69,7 +69,10 @@ SMPL_FRM_DB_FOLDER = "db"
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-1s5!+gf*u0x34#3+@1w%=np!^1o_ee$@$!_j2c!uh!aidkr3ja"
+SECRET_KEY = os.getenv(
+    "DJANGO_SECRET_KEY",
+    "django-insecure-1s5!+gf*u0x34#3+@1w%=np!^1o_ee$@$!_j2c!uh!aidkr3ja",
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False

--- a/src/smplfrm/smplfrm/tests/test_secret_key.py
+++ b/src/smplfrm/smplfrm/tests/test_secret_key.py
@@ -1,0 +1,31 @@
+"""Tests for reading SECRET_KEY from the DJANGO_SECRET_KEY environment variable."""
+
+import importlib
+import os
+from unittest.mock import patch
+
+DEV_FALLBACK = "django-insecure-1s5!+gf*u0x34#3+@1w%=np!^1o_ee$@$!_j2c!uh!aidkr3ja"
+
+
+def _reload_settings():
+    """Reload the settings module so patched env vars take effect."""
+    import smplfrm.settings as settings_module
+
+    return importlib.reload(settings_module)
+
+
+class TestSecretKeyFromEnv:
+    """SECRET_KEY should be read from DJANGO_SECRET_KEY env var."""
+
+    def test_uses_env_var_when_set(self):
+        """When DJANGO_SECRET_KEY is set, SECRET_KEY uses that value."""
+        with patch.dict(os.environ, {"DJANGO_SECRET_KEY": "my-production-key"}):
+            settings = _reload_settings()
+            assert settings.SECRET_KEY == "my-production-key"
+
+    def test_falls_back_to_dev_default_when_unset(self):
+        """When DJANGO_SECRET_KEY is not set, SECRET_KEY uses the dev fallback."""
+        env_without = {k: v for k, v in os.environ.items() if k != "DJANGO_SECRET_KEY"}
+        with patch.dict(os.environ, env_without, clear=True):
+            settings = _reload_settings()
+            assert settings.SECRET_KEY == DEV_FALLBACK


### PR DESCRIPTION
## Summary
Moves the hardcoded Django `SECRET_KEY` to the `DJANGO_SECRET_KEY` environment variable with a dev-only fallback, per #172.

## Changes
- **settings.py** — `SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", <insecure-dev-default>)`
- **test_secret_key.py** — Tests for env var override and fallback behavior
- **docs/Environment-Variables.md** — Documents `DJANGO_SECRET_KEY` with key generation instructions
- **docker/compose/config.env** — Adds `DJANGO_SECRET_KEY=change-me` placeholder
- **testing-best-practices.md** — Adds project-specific test commands

## Testing
- 2 new tests pass (env var override, dev fallback)
- Full suite: 340 passed, 2 pre-existing Spotify failures unrelated to this change

Closes #172