### PR TITLE
feat: add ESLint + Prettier for JS linting and formatting (#170)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,1 +1,5 @@
+# Black formatting commit
 dda4912538b3c7d166bf2a9e7ebf895b3d1c0b97
+
+# TODO: After merging PR #181 to main, add the final merge commit SHA below
+# (one-time Prettier format of all JS files — no logic changes)

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ For a full list of environment variables see the [Environment Variable wiki page
 
 ## Development
 
-### JavaScript Testing
-This project uses Vitest for JavaScript testing.
+### JavaScript
+This project uses [Vitest](https://vitest.dev/) for testing, [ESLint](https://eslint.org/) for linting, and [Prettier](https://prettier.io/) for formatting JavaScript files.
 
 **Setup:**
 ```bash
@@ -79,6 +79,14 @@ make packages-js
 make test-js              # Run tests once (silent mode)
 make test-js-watch        # Watch mode for development
 make test-js-coverage     # Generate coverage report
+```
+
+**Lint & format:**
+```bash
+npm run lint              # Check for lint errors
+npm run lint:fix          # Auto-fix lint errors
+npm run format            # Format all JS files with Prettier
+npm run format:check      # Check formatting without writing
 ```
 
 **Test location:** Tests are in `tests/javascript/` to avoid Django static bundling.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,32 @@
+import globals from 'globals';
+import eslintConfigPrettier from 'eslint-config-prettier';
+
+export default [
+  {
+    files: [
+      'src/**/static/**/*.js',
+      'tests/javascript/**/*.js',
+      'vitest.config.js',
+    ],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+      },
+    },
+    rules: {
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'no-undef': 'error',
+    },
+  },
+  {
+    files: ['tests/javascript/**/*.js', 'vitest.config.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+  eslintConfigPrettier,
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,11 @@
       "devDependencies": {
         "@vitest/coverage-v8": "^4.0.18",
         "@vitest/ui": "^4.0.18",
+        "eslint": "10.2.1",
+        "eslint-config-prettier": "10.1.8",
+        "globals": "17.5.0",
         "jsdom": "^25.0.1",
+        "prettier": "3.8.3",
         "vitest": "^4.0.18"
       }
     },
@@ -645,6 +649,179 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1055,10 +1232,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1226,6 +1417,29 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1234,6 +1448,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/assertion-error": {
@@ -1264,6 +1495,29 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -1300,6 +1554,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/cssstyle": {
@@ -1359,6 +1628,13 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1498,6 +1774,177 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1506,6 +1953,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -1517,6 +1974,27 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1542,6 +2020,50 @@
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -1629,6 +2151,32 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -1757,12 +2305,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -1851,6 +2449,67 @@
         }
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -1929,6 +2588,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -1965,6 +2640,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nwsapi": {
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
@@ -1983,6 +2665,56 @@
       ],
       "license": "MIT"
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -1994,6 +2726,26 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -2050,6 +2802,32 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {
@@ -2145,6 +2923,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/siginfo": {
@@ -2311,6 +3112,29 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -2527,6 +3351,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2542,6 +3382,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {
@@ -2582,6 +3432,19 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,20 @@
     "test": "vitest run --silent",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write 'src/**/static/**/*.js' 'tests/javascript/**/*.js' vitest.config.js eslint.config.js",
+    "format:check": "prettier --check 'src/**/static/**/*.js' 'tests/javascript/**/*.js' vitest.config.js eslint.config.js"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.18",
+    "eslint": "10.2.1",
+    "eslint-config-prettier": "10.1.8",
+    "globals": "17.5.0",
     "jsdom": "^25.0.1",
+    "prettier": "3.8.3",
     "vitest": "^4.0.18"
   }
 }

--- a/src/smplfrm/smplfrm/static/main.js
+++ b/src/smplfrm/smplfrm/static/main.js
@@ -1,461 +1,491 @@
-const IMAGE_ID_ATTR = "image-id";
+const IMAGE_ID_ATTR = 'image-id';
 const OPACITY_INCREMENT = 0.1;
 const OPACITY_MAX = 1.0;
 const CLOCK_REFRESH_MS = 1000;
 const SPOTIFY_REFRESH_MS = 5000;
 
-const imageContainer = document.getElementById("image-container");
-const progressBar = document.getElementById("progress-bar");
+const imageContainer = document.getElementById('image-container');
+const progressBar = document.getElementById('progress-bar');
 const config = window.SMPL_CONFIG;
 
 export function getWindowDimensions() {
-    return {
-        width: window.innerWidth,
-        height: window.innerHeight
-    };
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
 }
 
 export function buildApiUrl(endpoint) {
-    return `${config.host}:${config.port}/api/v1/${endpoint}`;
+  return `${config.host}:${config.port}/api/v1/${endpoint}`;
 }
 
 export function startProgress() {
-    let width = 100;
-    const interval = setInterval(() => {
-        width -= 1;
-        if (width <= 0) {
-            clearInterval(interval);
-            width = 0;
-        }
-        progressBar.style.width = `${width}%`;
-    }, config.refreshInterval / 100);
+  let width = 100;
+  const interval = setInterval(() => {
+    width -= 1;
+    if (width <= 0) {
+      clearInterval(interval);
+      width = 0;
+    }
+    progressBar.style.width = `${width}%`;
+  }, config.refreshInterval / 100);
 }
 
 export async function getNextImage() {
-    const { width, height } = getWindowDimensions();
-    const response = await fetch(buildApiUrl(`images/next?width=${width}&height=${height}`));
-    return response.json();
+  const { width, height } = getWindowDimensions();
+  const response = await fetch(
+    buildApiUrl(`images/next?width=${width}&height=${height}`),
+  );
+  return response.json();
 }
 
 async function displayMetadata(imageId) {
-    if (!config.displayDate) return;
+  if (!config.displayDate) return;
 
-    try {
-        const response = await fetch(buildApiUrl(`images_metadata?image__external_id=${imageId}`));
-        if (!response.ok) {
-            throw new Error(`Network response was not ok: ${response.statusText}`);
-        }
-        
-        const data = await response.json();
-        const takenDate = Date.parse(data[0].taken);
-        
-        if (isNaN(takenDate)) {
-            document.getElementById("photo-date").innerHTML = `📷`;
-        } else {
-            const prettyDate = new Intl.DateTimeFormat("en-US", {
-                year: "numeric",
-                month: "long"
-            }).format(takenDate);
-            document.getElementById("photo-date").innerHTML = `📷 ${prettyDate}`;
-        }
-    } catch (error) {
-        console.error('Fetch error:', error);
-        document.getElementById("photo-date").innerHTML = `📷`;
+  try {
+    const response = await fetch(
+      buildApiUrl(`images_metadata?image__external_id=${imageId}`),
+    );
+    if (!response.ok) {
+      throw new Error(`Network response was not ok: ${response.statusText}`);
     }
+
+    const data = await response.json();
+    const takenDate = Date.parse(data[0].taken);
+
+    if (isNaN(takenDate)) {
+      document.getElementById('photo-date').innerHTML = `📷`;
+    } else {
+      const prettyDate = new Intl.DateTimeFormat('en-US', {
+        year: 'numeric',
+        month: 'long',
+      }).format(takenDate);
+      document.getElementById('photo-date').innerHTML = `📷 ${prettyDate}`;
+    }
+  } catch (error) {
+    console.error('Fetch error:', error);
+    document.getElementById('photo-date').innerHTML = `📷`;
+  }
 }
 
 async function buildImage() {
-    const nextImage = await getNextImage();
-    const { width, height } = getWindowDimensions();
-    const img = new Image();
-    img.src = buildApiUrl(`images/${nextImage.id}/display?width=${width}&height=${height}`);
-    img.setAttribute(IMAGE_ID_ATTR, nextImage.id);
-    return img;
+  const nextImage = await getNextImage();
+  const { width, height } = getWindowDimensions();
+  const img = new Image();
+  img.src = buildApiUrl(
+    `images/${nextImage.id}/display?width=${width}&height=${height}`,
+  );
+  img.setAttribute(IMAGE_ID_ATTR, nextImage.id);
+  return img;
 }
 
 export function getRandomTransition() {
-    const transitions = ['fade', 'slide-left', 'slide-right', 'zoom'];
-    return transitions[Math.floor(Math.random() * transitions.length)];
+  const transitions = ['fade', 'slide-left', 'slide-right', 'zoom'];
+  return transitions[Math.floor(Math.random() * transitions.length)];
 }
 
 export function applyTransition(image, transitionType) {
-    const transition = transitionType === 'random' ? getRandomTransition() : transitionType;
-    const duration = config.transitionInterval / 1000;
-    
-    if (transition === 'fade') {
-        image.style.animation = `fadeIn ${duration}s linear forwards`;
-        image.style.opacity = '1';
-        return 'fade';
-    } else if (transition === 'slide-left') {
-        image.style.animation = `slideInLeft ${duration}s linear forwards`;
-        image.style.opacity = '1';
-        return 'slide-left';
-    } else if (transition === 'slide-right') {
-        image.style.animation = `slideInRight ${duration}s linear forwards`;
-        image.style.opacity = '1';
-        return 'slide-right';
-    } else if (transition === 'zoom') {
-        image.style.animation = `zoomInTransition ${duration}s linear forwards`;
-        image.style.opacity = '1';
-        return 'zoom';
-    } else if (transition === 'none') {
-        image.style.opacity = '1';
-        return 'none';
-    }
+  const transition =
+    transitionType === 'random' ? getRandomTransition() : transitionType;
+  const duration = config.transitionInterval / 1000;
+
+  if (transition === 'fade') {
+    image.style.animation = `fadeIn ${duration}s linear forwards`;
+    image.style.opacity = '1';
     return 'fade';
+  } else if (transition === 'slide-left') {
+    image.style.animation = `slideInLeft ${duration}s linear forwards`;
+    image.style.opacity = '1';
+    return 'slide-left';
+  } else if (transition === 'slide-right') {
+    image.style.animation = `slideInRight ${duration}s linear forwards`;
+    image.style.opacity = '1';
+    return 'slide-right';
+  } else if (transition === 'zoom') {
+    image.style.animation = `zoomInTransition ${duration}s linear forwards`;
+    image.style.opacity = '1';
+    return 'zoom';
+  } else if (transition === 'none') {
+    image.style.opacity = '1';
+    return 'none';
+  }
+  return 'fade';
 }
 
 export function fadeInImage(image, onComplete) {
-    const transitionType = applyTransition(image, config.imageTransitionType);
-    
-    if (transitionType === 'none') {
-        // No transition, apply zoom effect immediately if enabled
-        if (config.imageZoomEffect) {
-            const zoomDuration = config.refreshInterval / 1000;
-            image.style.animation = `zoomIn ${zoomDuration}s linear forwards`;
-        }
-        if (onComplete) onComplete();
-        return;
+  const transitionType = applyTransition(image, config.imageTransitionType);
+
+  if (transitionType === 'none') {
+    // No transition, apply zoom effect immediately if enabled
+    if (config.imageZoomEffect) {
+      const zoomDuration = config.refreshInterval / 1000;
+      image.style.animation = `zoomIn ${zoomDuration}s linear forwards`;
     }
-    
-    // CSS animation-based transitions
-    setTimeout(() => {
-        if (config.imageZoomEffect) {
-            const zoomDuration = config.refreshInterval / 1000;
-            image.style.animation = `zoomIn ${zoomDuration}s linear forwards`;
-        }
-        if (onComplete) onComplete();
-    }, config.transitionInterval);
+    if (onComplete) onComplete();
+    return;
+  }
+
+  // CSS animation-based transitions
+  setTimeout(() => {
+    if (config.imageZoomEffect) {
+      const zoomDuration = config.refreshInterval / 1000;
+      image.style.animation = `zoomIn ${zoomDuration}s linear forwards`;
+    }
+    if (onComplete) onComplete();
+  }, config.transitionInterval);
 }
 
 async function loadNext(currentImage) {
-    const newImage = await buildImage();
-    newImage.classList.add("main-img");
-    
-    newImage.onload = () => {
-        imageContainer.appendChild(newImage);
-        
-        setTimeout(() => {
-            fadeInImage(newImage, () => {
-                imageContainer.removeChild(currentImage);
-            });
-            displayMetadata(newImage.getAttribute(IMAGE_ID_ATTR));
-            startProgress();
-            loadNext(newImage);
-        }, config.refreshInterval);
-    };
+  const newImage = await buildImage();
+  newImage.classList.add('main-img');
+
+  newImage.onload = () => {
+    imageContainer.appendChild(newImage);
+
+    setTimeout(() => {
+      fadeInImage(newImage, () => {
+        imageContainer.removeChild(currentImage);
+      });
+      displayMetadata(newImage.getAttribute(IMAGE_ID_ATTR));
+      startProgress();
+      loadNext(newImage);
+    }, config.refreshInterval);
+  };
 }
 
 async function startImages() {
-    const newImage = await buildImage();
-    newImage.onload = () => {
-        newImage.classList.add("main-img");
-        imageContainer.appendChild(newImage);
-        
-        fadeInImage(newImage);
-        displayMetadata(newImage.getAttribute(IMAGE_ID_ATTR));
-        startProgress();
-        loadNext(newImage);
-    };
+  const newImage = await buildImage();
+  newImage.onload = () => {
+    newImage.classList.add('main-img');
+    imageContainer.appendChild(newImage);
+
+    fadeInImage(newImage);
+    displayMetadata(newImage.getAttribute(IMAGE_ID_ATTR));
+    startProgress();
+    loadNext(newImage);
+  };
 }
 
 function displayClock() {
-    const now = new Date();
-    
-    // Display current date
-    const currentDate = new Intl.DateTimeFormat("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric"
-    }).format(now);
-    document.getElementById("current-date").innerHTML = `📅 ${currentDate}`;
-    
-    // Display current time without seconds
-    const timeString = now.toLocaleTimeString('en-US', { 
-        hour: 'numeric', 
-        minute: '2-digit',
-        hour12: true 
-    });
-    document.getElementById("current-time").innerHTML = `🕐 ${timeString}`;
-    
-    setTimeout(displayClock, CLOCK_REFRESH_MS);
+  const now = new Date();
+
+  // Display current date
+  const currentDate = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(now);
+  document.getElementById('current-date').innerHTML = `📅 ${currentDate}`;
+
+  // Display current time without seconds
+  const timeString = now.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+  document.getElementById('current-time').innerHTML = `🕐 ${timeString}`;
+
+  setTimeout(displayClock, CLOCK_REFRESH_MS);
 }
 
 function displayWeather() {
-    const weatherGroup = document.getElementById('weather-group');
-    if (!config.plugins || !config.plugins.includes('weather')) {
-        weatherGroup.style.display = 'none';
-        return;
-    }
-    // Fetch weather data from plugin API
-    fetch(buildApiUrl('plugins/weather'))
-        .then(r => r.ok ? r.json() : null)
-        .then(data => {
-            if (data && data.current_temp) {
-                document.getElementById("weather-temp").innerHTML = `🌡️ ${data.current_temp}`;
-            }
-        })
-        .catch(() => {});
+  const weatherGroup = document.getElementById('weather-group');
+  if (!config.plugins || !config.plugins.includes('weather')) {
+    weatherGroup.style.display = 'none';
+    return;
+  }
+  // Fetch weather data from plugin API
+  fetch(buildApiUrl('plugins/weather'))
+    .then((r) => (r.ok ? r.json() : null))
+    .then((data) => {
+      if (data && data.current_temp) {
+        document.getElementById('weather-temp').innerHTML =
+          `🌡️ ${data.current_temp}`;
+      }
+    })
+    .catch(() => {});
 }
 
 function showSpotifyBar(content) {
-    const spotifyDiv = document.getElementById("spotify-now-playing");
-    spotifyDiv.innerHTML = content;
-    const bar = document.getElementById("spotify-bar");
-    bar.style.display = 'flex';
-    bar.classList.add('bar-fade-in');
+  const spotifyDiv = document.getElementById('spotify-now-playing');
+  spotifyDiv.innerHTML = content;
+  const bar = document.getElementById('spotify-bar');
+  bar.style.display = 'flex';
+  bar.classList.add('bar-fade-in');
 }
 
 export async function getNowPlaying() {
-    try {
-        const response = await fetch(buildApiUrl('plugins/spotify/now_playing'));
-        
-        if (!response.ok) {
-            const authResponse = await fetch(buildApiUrl('plugins/spotify/auth'));
-            if (!authResponse.ok) {
-                showSpotifyBar(`<i class="iconoir-spotify spotify-icon"></i>`);
-                return;
-            }
-            
-            const authData = await authResponse.json();
-            showSpotifyBar(`<a href="${authData.auth_url}"><i class="iconoir-spotify spotify-icon"></i></a>`);
-            return;
-        }
-        
-        const data = await response.json();
-        showSpotifyBar(`<i class="iconoir-spotify spotify-icon"></i> ${data.artist} - ${data.song}`);
-    } catch (error) {
-        console.error('Spotify error:', error);
+  try {
+    const response = await fetch(buildApiUrl('plugins/spotify/now_playing'));
+
+    if (!response.ok) {
+      const authResponse = await fetch(buildApiUrl('plugins/spotify/auth'));
+      if (!authResponse.ok) {
         showSpotifyBar(`<i class="iconoir-spotify spotify-icon"></i>`);
+        return;
+      }
+
+      const authData = await authResponse.json();
+      showSpotifyBar(
+        `<a href="${authData.auth_url}"><i class="iconoir-spotify spotify-icon"></i></a>`,
+      );
+      return;
     }
+
+    const data = await response.json();
+    showSpotifyBar(
+      `<i class="iconoir-spotify spotify-icon"></i> ${data.artist} - ${data.song}`,
+    );
+  } catch (error) {
+    console.error('Spotify error:', error);
+    showSpotifyBar(`<i class="iconoir-spotify spotify-icon"></i>`);
+  }
 }
 
 function refreshSpotify() {
-    getNowPlaying();
-    setTimeout(refreshSpotify, SPOTIFY_REFRESH_MS);
+  getNowPlaying();
+  setTimeout(refreshSpotify, SPOTIFY_REFRESH_MS);
 }
 
 export function init() {
-    initSettingsModal();
-    startImages();
+  initSettingsModal();
+  startImages();
 
-    if (config.displayClock) {
-        window.onload = displayClock;
-    } else {
-        document.getElementById('current-date-group').style.display = 'none';
-        document.getElementById('current-time-group').style.display = 'none';
-    }
+  if (config.displayClock) {
+    window.onload = displayClock;
+  } else {
+    document.getElementById('current-date-group').style.display = 'none';
+    document.getElementById('current-time-group').style.display = 'none';
+  }
 
-    if (!config.displayDate) {
-        document.getElementById('photo-date-group').style.display = 'none';
-    }
+  if (!config.displayDate) {
+    document.getElementById('photo-date-group').style.display = 'none';
+  }
 
-    displayWeather();
+  displayWeather();
 
-    // Hide separators between hidden groups
-    updateSeparators();
+  // Hide separators between hidden groups
+  updateSeparators();
 
-    if (config.plugins && config.plugins.includes('spotify')) {
-        refreshSpotify();
-    }
+  if (config.plugins && config.plugins.includes('spotify')) {
+    refreshSpotify();
+  }
 }
 
 export function updateSeparators() {
-    const bottomBar = document.getElementById('bottom-bar');
-    const groups = bottomBar.querySelectorAll('.info-group');
-    const separators = bottomBar.querySelectorAll('.group-separator');
+  const bottomBar = document.getElementById('bottom-bar');
+  const groups = bottomBar.querySelectorAll('.info-group');
+  const separators = bottomBar.querySelectorAll('.group-separator');
 
-    // Hide all separators first
-    separators.forEach(sep => sep.style.display = 'none');
+  // Hide all separators first
+  separators.forEach((sep) => (sep.style.display = 'none'));
 
-    // Show separators only between visible groups
-    const visibleGroups = Array.from(groups).filter(g => g.style.display !== 'none');
-    visibleGroups.forEach((group, index) => {
-        if (index < visibleGroups.length - 1) {
-            const sep = group.nextElementSibling;
-            if (sep && sep.classList.contains('group-separator')) {
-                sep.style.display = '';
-            }
-        }
-    });
-
-    // Hide bottom bar entirely when no groups are visible
-    if (visibleGroups.length === 0) {
-        bottomBar.style.display = 'none';
-    } else {
-        bottomBar.style.display = 'flex';
-        bottomBar.classList.add('bar-fade-in');
+  // Show separators only between visible groups
+  const visibleGroups = Array.from(groups).filter(
+    (g) => g.style.display !== 'none',
+  );
+  visibleGroups.forEach((group, index) => {
+    if (index < visibleGroups.length - 1) {
+      const sep = group.nextElementSibling;
+      if (sep && sep.classList.contains('group-separator')) {
+        sep.style.display = '';
+      }
     }
+  });
+
+  // Hide bottom bar entirely when no groups are visible
+  if (visibleGroups.length === 0) {
+    bottomBar.style.display = 'none';
+  } else {
+    bottomBar.style.display = 'flex';
+    bottomBar.classList.add('bar-fade-in');
+  }
 }
 
 async function loadConfig() {
-    const modal = document.getElementById('settings-modal');
-    const configId = modal.dataset.configId;
-    
-    try {
-        const response = await fetch(buildApiUrl(`configs/${configId}`));
-        if (!response.ok) throw new Error('Failed to load config');
-        
-        const config = await response.json();
-        
-        modal.dataset.configName = config.name;
-        modal.dataset.configPlugins = JSON.stringify(config.plugins || []);
-        document.getElementById('setting-date').checked = config.display_date;
-        document.getElementById('setting-clock').checked = config.display_clock;
-        document.getElementById('setting-refresh').value = config.image_refresh_interval;
-        document.getElementById('setting-transition').value = config.image_transition_interval;
-        document.getElementById('setting-zoom').checked = config.image_zoom_effect;
-        document.getElementById('setting-transition-type').value = config.image_transition_type;
-        document.getElementById('setting-cache-timeout').value = config.image_cache_timeout;
-        document.getElementById('setting-timezone').value = config.timezone;
-        document.getElementById('setting-fill-mode').value = config.image_fill_mode;
-        document.getElementById('setting-force-date-path').checked = config.force_date_from_path;
-    } catch (error) {
-        console.error('Error loading config:', error);
-    }
+  const modal = document.getElementById('settings-modal');
+  const configId = modal.dataset.configId;
+
+  try {
+    const response = await fetch(buildApiUrl(`configs/${configId}`));
+    if (!response.ok) throw new Error('Failed to load config');
+
+    const config = await response.json();
+
+    modal.dataset.configName = config.name;
+    modal.dataset.configPlugins = JSON.stringify(config.plugins || []);
+    document.getElementById('setting-date').checked = config.display_date;
+    document.getElementById('setting-clock').checked = config.display_clock;
+    document.getElementById('setting-refresh').value =
+      config.image_refresh_interval;
+    document.getElementById('setting-transition').value =
+      config.image_transition_interval;
+    document.getElementById('setting-zoom').checked = config.image_zoom_effect;
+    document.getElementById('setting-transition-type').value =
+      config.image_transition_type;
+    document.getElementById('setting-cache-timeout').value =
+      config.image_cache_timeout;
+    document.getElementById('setting-timezone').value = config.timezone;
+    document.getElementById('setting-fill-mode').value = config.image_fill_mode;
+    document.getElementById('setting-force-date-path').checked =
+      config.force_date_from_path;
+  } catch (error) {
+    console.error('Error loading config:', error);
+  }
 }
 
 async function saveConfig() {
-    const modal = document.getElementById('settings-modal');
-    let configId = modal.dataset.configId;
-    const configName = modal.dataset.configName;
-    const errorMessage = document.getElementById('error-message');
-    const cancelBtn = document.getElementById('cancel-settings');
-    
-    const configData = {
-        display_date: document.getElementById('setting-date').checked,
-        display_clock: document.getElementById('setting-clock').checked,
-        image_refresh_interval: parseInt(document.getElementById('setting-refresh').value),
-        image_transition_interval: parseInt(document.getElementById('setting-transition').value),
-        image_zoom_effect: document.getElementById('setting-zoom').checked,
-        image_transition_type: document.getElementById('setting-transition-type').value,
-        image_cache_timeout: parseInt(document.getElementById('setting-cache-timeout').value),
-        timezone: document.getElementById('setting-timezone').value,
-        image_fill_mode: document.getElementById('setting-fill-mode').value,
-        force_date_from_path: document.getElementById('setting-force-date-path').checked,
-        plugins: JSON.parse(modal.dataset.configPlugins || '[]')
-    };
-    
-    try {
-        // If active config is system-managed, create a custom copy first
-        if (configName && configName.startsWith('smplFrm ')) {
-            const applyResponse = await fetch(buildApiUrl('configs/apply'), {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' }
-            });
-            if (!applyResponse.ok) {
-                const err = await applyResponse.json();
-                throw new Error(err.detail || 'Failed to create custom config');
-            }
-            const newConfig = await applyResponse.json();
-            configId = newConfig.id;
-            modal.dataset.configId = configId;
-            modal.dataset.configName = newConfig.name;
-        }
+  const modal = document.getElementById('settings-modal');
+  let configId = modal.dataset.configId;
+  const configName = modal.dataset.configName;
+  const errorMessage = document.getElementById('error-message');
+  const cancelBtn = document.getElementById('cancel-settings');
 
-        configData.name = modal.dataset.configName;
+  const configData = {
+    display_date: document.getElementById('setting-date').checked,
+    display_clock: document.getElementById('setting-clock').checked,
+    image_refresh_interval: parseInt(
+      document.getElementById('setting-refresh').value,
+    ),
+    image_transition_interval: parseInt(
+      document.getElementById('setting-transition').value,
+    ),
+    image_zoom_effect: document.getElementById('setting-zoom').checked,
+    image_transition_type: document.getElementById('setting-transition-type')
+      .value,
+    image_cache_timeout: parseInt(
+      document.getElementById('setting-cache-timeout').value,
+    ),
+    timezone: document.getElementById('setting-timezone').value,
+    image_fill_mode: document.getElementById('setting-fill-mode').value,
+    force_date_from_path: document.getElementById('setting-force-date-path')
+      .checked,
+    plugins: JSON.parse(modal.dataset.configPlugins || '[]'),
+  };
 
-        const response = await fetch(buildApiUrl(`configs/${configId}`), {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(configData)
-        });
-        
-        if (!response.ok) {
-            const err = await response.json().catch(() => ({}));
-            throw new Error(err.detail || 'Failed to save settings');
-        }
-        
-        console.log('Settings saved successfully');
-        
-        // Mark that changes were saved
-        modal.dataset.changesSaved = 'true';
-        
-        // Change cancel button to reload button
-        cancelBtn.textContent = 'Reload Now';
-        cancelBtn.classList.remove('btn-secondary');
-        cancelBtn.classList.add('btn-primary');
-        
-        return true;
-    } catch (error) {
-        console.error('Error saving config:', error);
-        errorMessage.textContent = error.message;
-        errorMessage.classList.add('show');
-
-        const saveBtn = document.getElementById('save-settings');
-        saveBtn.disabled = true;
-
-        setTimeout(() => {
-            errorMessage.classList.remove('show');
-            saveBtn.disabled = false;
-        }, 3000);
-        
-        return false;
+  try {
+    // If active config is system-managed, create a custom copy first
+    if (configName && configName.startsWith('smplFrm ')) {
+      const applyResponse = await fetch(buildApiUrl('configs/apply'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!applyResponse.ok) {
+        const err = await applyResponse.json();
+        throw new Error(err.detail || 'Failed to create custom config');
+      }
+      const newConfig = await applyResponse.json();
+      configId = newConfig.id;
+      modal.dataset.configId = configId;
+      modal.dataset.configName = newConfig.name;
     }
+
+    configData.name = modal.dataset.configName;
+
+    const response = await fetch(buildApiUrl(`configs/${configId}`), {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(configData),
+    });
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      throw new Error(err.detail || 'Failed to save settings');
+    }
+
+    console.log('Settings saved successfully');
+
+    // Mark that changes were saved
+    modal.dataset.changesSaved = 'true';
+
+    // Change cancel button to reload button
+    cancelBtn.textContent = 'Reload Now';
+    cancelBtn.classList.remove('btn-secondary');
+    cancelBtn.classList.add('btn-primary');
+
+    return true;
+  } catch (error) {
+    console.error('Error saving config:', error);
+    errorMessage.textContent = error.message;
+    errorMessage.classList.add('show');
+
+    const saveBtn = document.getElementById('save-settings');
+    saveBtn.disabled = true;
+
+    setTimeout(() => {
+      errorMessage.classList.remove('show');
+      saveBtn.disabled = false;
+    }, 3000);
+
+    return false;
+  }
 }
 
 export async function startTask(taskType) {
-    const toast = document.getElementById('task-toast');
-    const bar = document.getElementById('task-toast-bar');
-    const text = document.getElementById('task-toast-text');
-    try {
-        const response = await fetch(buildApiUrl('tasks'), {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ task_type: taskType })
-        });
-        if (response.status === 409) {
-            const data = await response.json();
-            toast.classList.add('show');
-            bar.style.width = '0%';
-            text.textContent = data.detail || 'Task already running';
-            setTimeout(() => toast.classList.remove('show'), 3000);
-            return null;
-        }
-        if (!response.ok) throw new Error('Failed to start task');
-        const task = await response.json();
-        pollTask(task.id, task.task_type_label);
-        return task;
-    } catch (error) {
-        console.error('Error starting task:', error);
-        toast.classList.add('show');
-        bar.style.width = '0%';
-        text.textContent = 'Failed to start task';
-        setTimeout(() => toast.classList.remove('show'), 3000);
-        return null;
+  const toast = document.getElementById('task-toast');
+  const bar = document.getElementById('task-toast-bar');
+  const text = document.getElementById('task-toast-text');
+  try {
+    const response = await fetch(buildApiUrl('tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ task_type: taskType }),
+    });
+    if (response.status === 409) {
+      const data = await response.json();
+      toast.classList.add('show');
+      bar.style.width = '0%';
+      text.textContent = data.detail || 'Task already running';
+      setTimeout(() => toast.classList.remove('show'), 3000);
+      return null;
     }
+    if (!response.ok) throw new Error('Failed to start task');
+    const task = await response.json();
+    pollTask(task.id, task.task_type_label);
+    return task;
+  } catch (error) {
+    console.error('Error starting task:', error);
+    toast.classList.add('show');
+    bar.style.width = '0%';
+    text.textContent = 'Failed to start task';
+    setTimeout(() => toast.classList.remove('show'), 3000);
+    return null;
+  }
 }
 
 function pollTask(taskId, label) {
-    const toast = document.getElementById('task-toast');
-    const bar = document.getElementById('task-toast-bar');
-    const text = document.getElementById('task-toast-text');
+  const toast = document.getElementById('task-toast');
+  const bar = document.getElementById('task-toast-bar');
+  const text = document.getElementById('task-toast-text');
 
-    toast.classList.add('show');
-    text.textContent = `${label} 0%`;
-    bar.style.width = '0%';
+  toast.classList.add('show');
+  text.textContent = `${label} 0%`;
+  bar.style.width = '0%';
 
-    const interval = setInterval(async () => {
-        try {
-            const response = await fetch(buildApiUrl(`tasks/${taskId}`));
-            if (!response.ok) throw new Error('Poll failed');
-            const task = await response.json();
+  const interval = setInterval(async () => {
+    try {
+      const response = await fetch(buildApiUrl(`tasks/${taskId}`));
+      if (!response.ok) throw new Error('Poll failed');
+      const task = await response.json();
 
-            bar.style.width = `${task.progress}%`;
-            text.textContent = `${label} ${task.progress}%`;
+      bar.style.width = `${task.progress}%`;
+      text.textContent = `${label} ${task.progress}%`;
 
-            if (task.status === 'completed' || task.status === 'failed') {
-                clearInterval(interval);
-                text.textContent = task.status === 'completed' ? `${label} Done!` : `${label} Failed: ${task.error}`;
-                setTimeout(() => toast.classList.remove('show'), 3000);
-            }
-        } catch {
-            clearInterval(interval);
-            toast.classList.remove('show');
-        }
-    }, 1000);
+      if (task.status === 'completed' || task.status === 'failed') {
+        clearInterval(interval);
+        text.textContent =
+          task.status === 'completed'
+            ? `${label} Done!`
+            : `${label} Failed: ${task.error}`;
+        setTimeout(() => toast.classList.remove('show'), 3000);
+      }
+    } catch {
+      clearInterval(interval);
+      toast.classList.remove('show');
+    }
+  }, 1000);
 }
 
 let taskPage = 1;
@@ -464,493 +494,534 @@ let presetPage = 1;
 let pluginPage = 1;
 
 export async function loadPlugins(page = 1) {
-    pluginPage = page;
-    document.getElementById('plugin-list-view').style.display = '';
-    document.getElementById('plugin-detail-view').style.display = 'none';
-    document.getElementById('main-actions').style.display = '';
-    document.getElementById('plugin-detail-actions').style.display = 'none';
-    const body = document.getElementById('plugin-list-body');
-    const modal = document.getElementById('settings-modal');
-    const prev = document.getElementById('plugin-page-prev');
-    const next = document.getElementById('plugin-page-next');
-    const info = document.getElementById('plugin-page-info');
-    const enabledPlugins = JSON.parse(modal.dataset.configPlugins || '[]');
+  pluginPage = page;
+  document.getElementById('plugin-list-view').style.display = '';
+  document.getElementById('plugin-detail-view').style.display = 'none';
+  document.getElementById('main-actions').style.display = '';
+  document.getElementById('plugin-detail-actions').style.display = 'none';
+  const body = document.getElementById('plugin-list-body');
+  const modal = document.getElementById('settings-modal');
+  const prev = document.getElementById('plugin-page-prev');
+  const next = document.getElementById('plugin-page-next');
+  const info = document.getElementById('plugin-page-info');
+  const enabledPlugins = JSON.parse(modal.dataset.configPlugins || '[]');
 
-    try {
-        const response = await fetch(buildApiUrl(`plugins?page=${page}`));
-        if (!response.ok) throw new Error('Failed to load plugins');
-        const data = await response.json();
+  try {
+    const response = await fetch(buildApiUrl(`plugins?page=${page}`));
+    if (!response.ok) throw new Error('Failed to load plugins');
+    const data = await response.json();
 
-        body.innerHTML = data.results.map(p => {
-            const isEnabled = enabledPlugins.includes(p.name);
-            const checked = isEnabled ? 'checked' : '';
-            return `<tr>
+    body.innerHTML = data.results
+      .map((p) => {
+        const isEnabled = enabledPlugins.includes(p.name);
+        const checked = isEnabled ? 'checked' : '';
+        return `<tr>
                 <td>${p.name}</td>
                 <td>${p.description || ''}</td>
                 <td><button class="btn btn-secondary btn-sm plugin-configure-btn" data-id="${p.id}">Configure</button></td>
                 <td><label class="toggle-switch plugin-toggle-wrap"><input type="checkbox" class="plugin-toggle" data-name="${p.name}" ${checked}><span class="slider"></span></label></td>
             </tr>`;
-        }).join('');
+      })
+      .join('');
 
-        // Toggles only update local state — Save button does the PUT
-        body.querySelectorAll('.plugin-toggle').forEach(toggle => {
-            toggle.addEventListener('change', () => {
-                const name = toggle.dataset.name;
-                if (toggle.checked) {
-                    if (!enabledPlugins.includes(name)) enabledPlugins.push(name);
-                } else {
-                    const idx = enabledPlugins.indexOf(name);
-                    if (idx > -1) enabledPlugins.splice(idx, 1);
-                }
-                modal.dataset.configPlugins = JSON.stringify(enabledPlugins);
-            });
-        });
+    // Toggles only update local state — Save button does the PUT
+    body.querySelectorAll('.plugin-toggle').forEach((toggle) => {
+      toggle.addEventListener('change', () => {
+        const name = toggle.dataset.name;
+        if (toggle.checked) {
+          if (!enabledPlugins.includes(name)) enabledPlugins.push(name);
+        } else {
+          const idx = enabledPlugins.indexOf(name);
+          if (idx > -1) enabledPlugins.splice(idx, 1);
+        }
+        modal.dataset.configPlugins = JSON.stringify(enabledPlugins);
+      });
+    });
 
-        // Configure button opens detail view
-        body.querySelectorAll('.plugin-configure-btn').forEach(btn => {
-            btn.addEventListener('click', () => openPluginDetail(btn.dataset.id));
-        });
+    // Configure button opens detail view
+    body.querySelectorAll('.plugin-configure-btn').forEach((btn) => {
+      btn.addEventListener('click', () => openPluginDetail(btn.dataset.id));
+    });
 
-        const totalPages = Math.ceil(data.count / 5) || 1;
-        info.textContent = `Page ${page} of ${totalPages}`;
-        prev.disabled = !data.previous;
-        next.disabled = !data.next;
-    } catch {
-        body.innerHTML = '<tr><td colspan="4">Failed to load plugins</td></tr>';
-    }
+    const totalPages = Math.ceil(data.count / 5) || 1;
+    info.textContent = `Page ${page} of ${totalPages}`;
+    prev.disabled = !data.previous;
+    next.disabled = !data.next;
+  } catch {
+    body.innerHTML = '<tr><td colspan="4">Failed to load plugins</td></tr>';
+  }
 }
 
 export function validateCoordinates(value) {
-    const trimmed = value.trim();
-    if (trimmed === '') return true;
+  const trimmed = value.trim();
+  if (trimmed === '') return true;
 
-    const parts = trimmed.split(',');
-    if (parts.length !== 2) return false;
+  const parts = trimmed.split(',');
+  if (parts.length !== 2) return false;
 
-    const latStr = parts[0].trim();
-    const lonStr = parts[1].trim();
-    if (latStr === '' || lonStr === '') return false;
+  const latStr = parts[0].trim();
+  const lonStr = parts[1].trim();
+  if (latStr === '' || lonStr === '') return false;
 
-    const lat = Number(latStr);
-    const lon = Number(lonStr);
-    if (isNaN(lat) || isNaN(lon)) return false;
+  const lat = Number(latStr);
+  const lon = Number(lonStr);
+  if (isNaN(lat) || isNaN(lon)) return false;
 
-    return lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+  return lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
 }
 
 export const PLUGIN_ACTION_HANDLERS = {
-    geolocation: (input) => {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'action-btn';
+  geolocation: (input) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'action-btn';
+    btn.textContent = '📍';
+    btn.title = 'Look up coordinates';
+    btn.addEventListener('click', () => {
+      window.open('https://www.latlong.net', '_blank');
+      btn.textContent = '🌐';
+      setTimeout(() => {
         btn.textContent = '📍';
-        btn.title = 'Look up coordinates';
-        btn.addEventListener('click', () => {
-            window.open('https://www.latlong.net', '_blank');
-            btn.textContent = '🌐';
-            setTimeout(() => { btn.textContent = '📍'; }, 1500);
-        });
+      }, 1500);
+    });
 
-        return btn;
-    }
+    return btn;
+  },
 };
 
 async function openPluginDetail(pluginId) {
-    const listView = document.getElementById('plugin-list-view');
-    const detailView = document.getElementById('plugin-detail-view');
-    const nameEl = document.getElementById('plugin-detail-name');
-    const formEl = document.getElementById('plugin-detail-form');
+  const listView = document.getElementById('plugin-list-view');
+  const detailView = document.getElementById('plugin-detail-view');
+  const nameEl = document.getElementById('plugin-detail-name');
+  const formEl = document.getElementById('plugin-detail-form');
 
-    const resp = await fetch(buildApiUrl(`plugins/${pluginId}`));
-    if (!resp.ok) return;
-    const plugin = await resp.json();
+  const resp = await fetch(buildApiUrl(`plugins/${pluginId}`));
+  if (!resp.ok) return;
+  const plugin = await resp.json();
 
-    nameEl.textContent = plugin.name;
-    formEl.innerHTML = '';
+  nameEl.textContent = plugin.name;
+  formEl.innerHTML = '';
 
-    (plugin.settings_schema || []).forEach(field => {
-        const div = document.createElement('div');
-        div.className = 'setting-item';
+  (plugin.settings_schema || []).forEach((field) => {
+    const div = document.createElement('div');
+    div.className = 'setting-item';
 
-        const label = document.createElement('label');
-        label.textContent = field.label;
-        div.appendChild(label);
+    const label = document.createElement('label');
+    label.textContent = field.label;
+    div.appendChild(label);
 
-        const row = document.createElement('div');
-        row.className = 'field-row';
+    const row = document.createElement('div');
+    row.className = 'field-row';
 
-        let input;
-        if (field.type === 'select') {
-            input = document.createElement('select');
-            input.className = 'select-input';
-            (field.options || []).forEach(opt => {
-                const option = document.createElement('option');
-                option.value = opt;
-                option.textContent = opt;
-                input.appendChild(option);
-            });
-            input.value = plugin.settings[field.key] || '';
-        } else if (field.type === 'toggle') {
-            const toggleLabel = document.createElement('label');
-            toggleLabel.className = 'toggle-switch';
-            input = document.createElement('input');
-            input.type = 'checkbox';
-            input.checked = !!plugin.settings[field.key];
-            const slider = document.createElement('span');
-            slider.className = 'slider';
-            toggleLabel.appendChild(input);
-            toggleLabel.appendChild(slider);
-            row.appendChild(toggleLabel);
-        } else {
-            input = document.createElement('input');
-            input.type = field.type === 'password' ? 'password' : 'text';
-            input.className = 'select-input';
-            input.value = plugin.settings[field.key] || '';
-            if (field.type === 'password') {
-                const reveal = document.createElement('button');
-                reveal.type = 'button';
-                reveal.className = 'reveal-btn';
-                reveal.textContent = '👁';
-                reveal.addEventListener('click', () => {
-                    input.type = input.type === 'password' ? 'text' : 'password';
-                });
-                row.appendChild(input);
-                row.appendChild(reveal);
-            }
-        }
-
-        input.dataset.key = field.key;
-        input.classList.add('plugin-setting-input');
-
-        if (field.type !== 'password' && field.type !== 'toggle') row.appendChild(input);
-
-        if (field.action && PLUGIN_ACTION_HANDLERS[field.action]) {
-            row.appendChild(PLUGIN_ACTION_HANDLERS[field.action](input));
-        }
-
-        div.appendChild(row);
-        formEl.appendChild(div);
-    });
-
-    // Save handler
-    const saveBtn = document.getElementById('plugin-detail-save');
-    const newSave = saveBtn.cloneNode(true);
-    saveBtn.parentNode.replaceChild(newSave, saveBtn);
-    newSave.addEventListener('click', async () => {
-        // Validate coordinates before saving
-        const coordInputs = formEl.querySelectorAll('.plugin-setting-input');
-        for (const el of coordInputs) {
-            if (el.type === 'checkbox' || el.type === 'select-one') continue;
-            if (!validateCoordinates(el.value)) {
-                const errorMessage = document.getElementById('error-message');
-                errorMessage.textContent = 'Invalid coordinates. Use lat,long format (e.g. 40.7128,-74.0060)';
-                errorMessage.classList.add('show');
-                newSave.disabled = true;
-                setTimeout(() => {
-                    errorMessage.classList.remove('show');
-                    newSave.disabled = false;
-                }, 3000);
-                return;
-            }
-        }
-
-        const settings = {};
-        formEl.querySelectorAll('.plugin-setting-input').forEach(el => {
-            settings[el.dataset.key] = el.type === 'checkbox' ? el.checked : el.value;
+    let input;
+    if (field.type === 'select') {
+      input = document.createElement('select');
+      input.className = 'select-input';
+      (field.options || []).forEach((opt) => {
+        const option = document.createElement('option');
+        option.value = opt;
+        option.textContent = opt;
+        input.appendChild(option);
+      });
+      input.value = plugin.settings[field.key] || '';
+    } else if (field.type === 'toggle') {
+      const toggleLabel = document.createElement('label');
+      toggleLabel.className = 'toggle-switch';
+      input = document.createElement('input');
+      input.type = 'checkbox';
+      input.checked = !!plugin.settings[field.key];
+      const slider = document.createElement('span');
+      slider.className = 'slider';
+      toggleLabel.appendChild(input);
+      toggleLabel.appendChild(slider);
+      row.appendChild(toggleLabel);
+    } else {
+      input = document.createElement('input');
+      input.type = field.type === 'password' ? 'password' : 'text';
+      input.className = 'select-input';
+      input.value = plugin.settings[field.key] || '';
+      if (field.type === 'password') {
+        const reveal = document.createElement('button');
+        reveal.type = 'button';
+        reveal.className = 'reveal-btn';
+        reveal.textContent = '👁';
+        reveal.addEventListener('click', () => {
+          input.type = input.type === 'password' ? 'text' : 'password';
         });
-        await fetch(buildApiUrl(`plugins/${pluginId}`), {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ settings })
-        });
-        newSave.textContent = 'Saved!';
-        setTimeout(() => { newSave.textContent = 'Save'; }, 1500);
+        row.appendChild(input);
+        row.appendChild(reveal);
+      }
+    }
 
-        const modal = document.getElementById('settings-modal');
-        modal.dataset.changesSaved = 'true';
-        const cancelBtn = document.getElementById('cancel-settings');
-        cancelBtn.textContent = 'Reload Now';
-        cancelBtn.classList.remove('btn-secondary');
-        cancelBtn.classList.add('btn-primary');
+    input.dataset.key = field.key;
+    input.classList.add('plugin-setting-input');
+
+    if (field.type !== 'password' && field.type !== 'toggle')
+      row.appendChild(input);
+
+    if (field.action && PLUGIN_ACTION_HANDLERS[field.action]) {
+      row.appendChild(PLUGIN_ACTION_HANDLERS[field.action](input));
+    }
+
+    div.appendChild(row);
+    formEl.appendChild(div);
+  });
+
+  // Save handler
+  const saveBtn = document.getElementById('plugin-detail-save');
+  const newSave = saveBtn.cloneNode(true);
+  saveBtn.parentNode.replaceChild(newSave, saveBtn);
+  newSave.addEventListener('click', async () => {
+    // Validate coordinates before saving
+    const coordInputs = formEl.querySelectorAll('.plugin-setting-input');
+    for (const el of coordInputs) {
+      if (el.type === 'checkbox' || el.type === 'select-one') continue;
+      if (!validateCoordinates(el.value)) {
+        const errorMessage = document.getElementById('error-message');
+        errorMessage.textContent =
+          'Invalid coordinates. Use lat,long format (e.g. 40.7128,-74.0060)';
+        errorMessage.classList.add('show');
+        newSave.disabled = true;
+        setTimeout(() => {
+          errorMessage.classList.remove('show');
+          newSave.disabled = false;
+        }, 3000);
+        return;
+      }
+    }
+
+    const settings = {};
+    formEl.querySelectorAll('.plugin-setting-input').forEach((el) => {
+      settings[el.dataset.key] = el.type === 'checkbox' ? el.checked : el.value;
     });
+    await fetch(buildApiUrl(`plugins/${pluginId}`), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ settings }),
+    });
+    newSave.textContent = 'Saved!';
+    setTimeout(() => {
+      newSave.textContent = 'Save';
+    }, 1500);
 
-    listView.style.display = 'none';
-    detailView.style.display = '';
-    document.getElementById('main-actions').style.display = 'none';
-    document.getElementById('plugin-detail-actions').style.display = '';
+    const modal = document.getElementById('settings-modal');
+    modal.dataset.changesSaved = 'true';
+    const cancelBtn = document.getElementById('cancel-settings');
+    cancelBtn.textContent = 'Reload Now';
+    cancelBtn.classList.remove('btn-secondary');
+    cancelBtn.classList.add('btn-primary');
+  });
 
-    // Back button
-    const backBtn = document.getElementById('plugin-detail-back');
-    const newBack = backBtn.cloneNode(true);
-    backBtn.parentNode.replaceChild(newBack, backBtn);
-    newBack.addEventListener('click', () => loadPlugins(pluginPage));
+  listView.style.display = 'none';
+  detailView.style.display = '';
+  document.getElementById('main-actions').style.display = 'none';
+  document.getElementById('plugin-detail-actions').style.display = '';
+
+  // Back button
+  const backBtn = document.getElementById('plugin-detail-back');
+  const newBack = backBtn.cloneNode(true);
+  backBtn.parentNode.replaceChild(newBack, backBtn);
+  newBack.addEventListener('click', () => loadPlugins(pluginPage));
 }
 
 export async function loadPresets(page = 1) {
-    presetPage = page;
-    const body = document.getElementById('preset-list-body');
-    const prev = document.getElementById('preset-page-prev');
-    const next = document.getElementById('preset-page-next');
-    const info = document.getElementById('preset-page-info');
-    const modal = document.getElementById('settings-modal');
-    const activeConfigId = modal.dataset.configId;
+  presetPage = page;
+  const body = document.getElementById('preset-list-body');
+  const prev = document.getElementById('preset-page-prev');
+  const next = document.getElementById('preset-page-next');
+  const info = document.getElementById('preset-page-info');
+  const modal = document.getElementById('settings-modal');
+  const activeConfigId = modal.dataset.configId;
 
-    try {
-        const response = await fetch(buildApiUrl(`configs?page=${page}`));
-        if (!response.ok) throw new Error('Failed to load presets');
-        const data = await response.json();
+  try {
+    const response = await fetch(buildApiUrl(`configs?page=${page}`));
+    if (!response.ok) throw new Error('Failed to load presets');
+    const data = await response.json();
 
-        body.innerHTML = data.results.map(c => {
-            const isManaged = c.name.startsWith('smplFrm ');
-            const nameCell = isManaged
-                ? `<td>${c.name}</td>`
-                : `<td class="editable" contenteditable="true" data-id="${c.id}" data-field="name">${c.name}</td>`;
-            const descCell = isManaged
-                ? `<td>${c.description || ''}</td>`
-                : `<td class="editable" contenteditable="true" data-id="${c.id}" data-field="description">${c.description || ''}</td>`;
-            const status = c.is_active
-                ? '<span class="badge-active">Active</span>'
-                : `<button class="btn btn-secondary btn-sm preset-activate-btn" data-id="${c.id}">Activate</button>`;
-            const deleteBtn = (!isManaged && !c.is_active)
-                ? `<button class="btn btn-secondary btn-sm task-delete-btn preset-delete-btn" data-id="${c.id}">&times;</button>`
-                : isManaged
-                    ? `<span class="delete-disabled" title="System-managed configs cannot be deleted">🔒</span>`
-                    : `<span class="delete-disabled" title="Active config cannot be deleted">🔒</span>`;
-            return `<tr>${nameCell}${descCell}<td>${status}</td><td>${deleteBtn}</td></tr>`;
-        }).join('');
+    body.innerHTML = data.results
+      .map((c) => {
+        const isManaged = c.name.startsWith('smplFrm ');
+        const nameCell = isManaged
+          ? `<td>${c.name}</td>`
+          : `<td class="editable" contenteditable="true" data-id="${c.id}" data-field="name">${c.name}</td>`;
+        const descCell = isManaged
+          ? `<td>${c.description || ''}</td>`
+          : `<td class="editable" contenteditable="true" data-id="${c.id}" data-field="description">${c.description || ''}</td>`;
+        const status = c.is_active
+          ? '<span class="badge-active">Active</span>'
+          : `<button class="btn btn-secondary btn-sm preset-activate-btn" data-id="${c.id}">Activate</button>`;
+        const deleteBtn =
+          !isManaged && !c.is_active
+            ? `<button class="btn btn-secondary btn-sm task-delete-btn preset-delete-btn" data-id="${c.id}">&times;</button>`
+            : isManaged
+              ? `<span class="delete-disabled" title="System-managed configs cannot be deleted">🔒</span>`
+              : `<span class="delete-disabled" title="Active config cannot be deleted">🔒</span>`;
+        return `<tr>${nameCell}${descCell}<td>${status}</td><td>${deleteBtn}</td></tr>`;
+      })
+      .join('');
 
-        body.querySelectorAll('.editable').forEach(cell => {
-            cell.dataset.original = cell.textContent.trim();
-            const save = async () => {
-                const value = cell.textContent.trim();
-                if (value === cell.dataset.original) return;
-                const id = cell.dataset.id;
-                const field = cell.dataset.field;
-                try {
-                    const getResp = await fetch(buildApiUrl(`configs/${id}`));
-                    if (!getResp.ok) return;
-                    const config = await getResp.json();
-                    config[field] = value;
-                    delete config.id;
-                    delete config.is_active;
-                    await fetch(buildApiUrl(`configs/${id}`), {
-                        method: 'PUT',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify(config)
-                    });
-                    cell.dataset.original = value;
-                } catch (e) {
-                    console.error('Failed to save:', e);
-                }
-            };
-            cell.addEventListener('blur', save);
-            cell.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter') { e.preventDefault(); cell.blur(); }
-            });
+    body.querySelectorAll('.editable').forEach((cell) => {
+      cell.dataset.original = cell.textContent.trim();
+      const save = async () => {
+        const value = cell.textContent.trim();
+        if (value === cell.dataset.original) return;
+        const id = cell.dataset.id;
+        const field = cell.dataset.field;
+        try {
+          const getResp = await fetch(buildApiUrl(`configs/${id}`));
+          if (!getResp.ok) return;
+          const config = await getResp.json();
+          config[field] = value;
+          delete config.id;
+          delete config.is_active;
+          await fetch(buildApiUrl(`configs/${id}`), {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(config),
+          });
+          cell.dataset.original = value;
+        } catch (e) {
+          console.error('Failed to save:', e);
+        }
+      };
+      cell.addEventListener('blur', save);
+      cell.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          cell.blur();
+        }
+      });
+    });
+
+    body.querySelectorAll('.preset-activate-btn').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-inline"></span>';
+        try {
+          const resp = await fetch(
+            buildApiUrl(`configs/${btn.dataset.id}/activate`),
+            { method: 'POST' },
+          );
+          if (!resp.ok) throw new Error('Failed to activate');
+          location.reload();
+        } catch {
+          btn.disabled = false;
+          btn.textContent = 'Activate';
+        }
+      });
+    });
+
+    body.querySelectorAll('.preset-delete-btn').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        await fetch(buildApiUrl(`configs/${btn.dataset.id}`), {
+          method: 'DELETE',
         });
+        loadPresets(presetPage);
+      });
+    });
 
-        body.querySelectorAll('.preset-activate-btn').forEach(btn => {
-            btn.addEventListener('click', async () => {
-                btn.disabled = true;
-                btn.innerHTML = '<span class="spinner-inline"></span>';
-                try {
-                    const resp = await fetch(buildApiUrl(`configs/${btn.dataset.id}/activate`), { method: 'POST' });
-                    if (!resp.ok) throw new Error('Failed to activate');
-                    location.reload();
-                } catch {
-                    btn.disabled = false;
-                    btn.textContent = 'Activate';
-                }
-            });
-        });
-
-        body.querySelectorAll('.preset-delete-btn').forEach(btn => {
-            btn.addEventListener('click', async () => {
-                await fetch(buildApiUrl(`configs/${btn.dataset.id}`), { method: 'DELETE' });
-                loadPresets(presetPage);
-            });
-        });
-
-        const totalPages = Math.ceil(data.count / 5) || 1;
-        info.textContent = `Page ${page} of ${totalPages}`;
-        prev.disabled = !data.previous;
-        next.disabled = !data.next;
-    } catch {
-        body.innerHTML = '<tr><td colspan="4">Failed to load presets</td></tr>';
-    }
+    const totalPages = Math.ceil(data.count / 5) || 1;
+    info.textContent = `Page ${page} of ${totalPages}`;
+    prev.disabled = !data.previous;
+    next.disabled = !data.next;
+  } catch {
+    body.innerHTML = '<tr><td colspan="4">Failed to load presets</td></tr>';
+  }
 }
 
 export async function loadTasks(page = 1) {
-    taskPage = page;
-    const body = document.getElementById('task-list-body');
-    const prev = document.getElementById('task-page-prev');
-    const next = document.getElementById('task-page-next');
-    const info = document.getElementById('task-page-info');
+  taskPage = page;
+  const body = document.getElementById('task-list-body');
+  const prev = document.getElementById('task-page-prev');
+  const next = document.getElementById('task-page-next');
+  const info = document.getElementById('task-page-info');
 
-    try {
-        const response = await fetch(buildApiUrl(`tasks?page=${page}`));
-        if (!response.ok) throw new Error('Failed to load tasks');
-        const data = await response.json();
+  try {
+    const response = await fetch(buildApiUrl(`tasks?page=${page}`));
+    if (!response.ok) throw new Error('Failed to load tasks');
+    const data = await response.json();
 
-        body.innerHTML = data.results.map(t => {
-            const created = new Date(t.created).toLocaleString();
-            return `<tr data-id="${t.id}"><td>${t.task_type_label}</td><td>${t.status}</td><td>${t.progress}%</td><td>${created}</td><td><button class="btn btn-secondary btn-sm task-delete-btn" data-id="${t.id}">&times;</button></td></tr>`;
-        }).join('');
+    body.innerHTML = data.results
+      .map((t) => {
+        const created = new Date(t.created).toLocaleString();
+        return `<tr data-id="${t.id}"><td>${t.task_type_label}</td><td>${t.status}</td><td>${t.progress}%</td><td>${created}</td><td><button class="btn btn-secondary btn-sm task-delete-btn" data-id="${t.id}">&times;</button></td></tr>`;
+      })
+      .join('');
 
-        body.querySelectorAll('.task-delete-btn').forEach(btn => {
-            btn.addEventListener('click', async () => {
-                await fetch(buildApiUrl(`tasks/${btn.dataset.id}`), { method: 'DELETE' });
-                loadTasks(taskPage);
-            });
+    body.querySelectorAll('.task-delete-btn').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        await fetch(buildApiUrl(`tasks/${btn.dataset.id}`), {
+          method: 'DELETE',
         });
+        loadTasks(taskPage);
+      });
+    });
 
-        const totalPages = Math.ceil(data.count / 5) || 1;
-        info.textContent = `Page ${page} of ${totalPages}`;
-        prev.disabled = !data.previous;
-        next.disabled = !data.next;
-    } catch {
-        body.innerHTML = '<tr><td colspan="5">Failed to load tasks</td></tr>';
-    }
+    const totalPages = Math.ceil(data.count / 5) || 1;
+    info.textContent = `Page ${page} of ${totalPages}`;
+    prev.disabled = !data.previous;
+    next.disabled = !data.next;
+  } catch {
+    body.innerHTML = '<tr><td colspan="5">Failed to load tasks</td></tr>';
+  }
 }
 
 function initSettingsModal() {
-    const modal = document.getElementById('settings-modal');
-    const logoIcon = document.getElementById('logo-icon');
-    const closeBtn = document.getElementById('close-modal');
-    const cancelBtn = document.getElementById('cancel-settings');
-    const saveBtn = document.getElementById('save-settings');
-    const tabBtns = document.querySelectorAll('.tab-btn');
+  const modal = document.getElementById('settings-modal');
+  const logoIcon = document.getElementById('logo-icon');
+  const closeBtn = document.getElementById('close-modal');
+  const cancelBtn = document.getElementById('cancel-settings');
+  const saveBtn = document.getElementById('save-settings');
+  const tabBtns = document.querySelectorAll('.tab-btn');
 
-    logoIcon.addEventListener('click', async () => {
-        modal.classList.add('open');
-        modal.dataset.changesSaved = 'false';
-        cancelBtn.textContent = 'Cancel';
-        cancelBtn.classList.remove('btn-primary');
-        cancelBtn.classList.add('btn-secondary');
+  logoIcon.addEventListener('click', async () => {
+    modal.classList.add('open');
+    modal.dataset.changesSaved = 'false';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.classList.remove('btn-primary');
+    cancelBtn.classList.add('btn-secondary');
 
-        // Reset plugin detail view
-        document.getElementById('plugin-detail-view').style.display = 'none';
-        document.getElementById('plugin-list-view').style.display = '';
-        document.getElementById('main-actions').style.display = '';
+    // Reset plugin detail view
+    document.getElementById('plugin-detail-view').style.display = 'none';
+    document.getElementById('plugin-list-view').style.display = '';
+    document.getElementById('main-actions').style.display = '';
 
-        const activeTab = document.querySelector('.tab-content.active');
-        const sections = activeTab.querySelectorAll('.settings-section');
-        sections.forEach(s => s.style.display = 'none');
+    const activeTab = document.querySelector('.tab-content.active');
+    const sections = activeTab.querySelectorAll('.settings-section');
+    sections.forEach((s) => (s.style.display = 'none'));
+    const spinner = document.createElement('div');
+    spinner.className = 'spinner';
+    activeTab.appendChild(spinner);
+    await loadConfig();
+    spinner.remove();
+    sections.forEach((s) => (s.style.display = ''));
+
+    // Ensure plugin detail stays hidden after section restore
+    document.getElementById('plugin-detail-view').style.display = 'none';
+    document.getElementById('plugin-detail-actions').style.display = 'none';
+  });
+
+  const closeModal = () => {
+    const changesSaved = modal.dataset.changesSaved === 'true';
+    if (changesSaved) {
+      location.reload();
+    } else {
+      modal.classList.remove('open');
+    }
+  };
+
+  closeBtn.addEventListener('click', closeModal);
+  cancelBtn.addEventListener('click', closeModal);
+
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) {
+      closeModal();
+    }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && modal.classList.contains('open')) {
+      closeModal();
+    }
+  });
+
+  tabBtns.forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const tabName = btn.dataset.tab;
+
+      tabBtns.forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+
+      document.querySelectorAll('.tab-content').forEach((content) => {
+        content.classList.remove('active');
+      });
+      document.getElementById(`tab-${tabName}`).classList.add('active');
+
+      // Always restore main action buttons and hide plugin detail when switching tabs
+      document.getElementById('main-actions').style.display = '';
+      document.getElementById('plugin-detail-actions').style.display = 'none';
+      document.getElementById('plugin-detail-view').style.display = 'none';
+
+      if (tabName === 'tasks') {
+        const taskTab = document.getElementById('tab-tasks');
+        const sections = taskTab.querySelectorAll(
+          '.settings-section, .task-pagination',
+        );
+        sections.forEach((s) => (s.style.display = 'none'));
         const spinner = document.createElement('div');
         spinner.className = 'spinner';
-        activeTab.appendChild(spinner);
-        await loadConfig();
+        taskTab.appendChild(spinner);
+        await loadTasks();
         spinner.remove();
-        sections.forEach(s => s.style.display = '');
+        sections.forEach((s) => (s.style.display = ''));
+      }
 
-        // Ensure plugin detail stays hidden after section restore
+      if (tabName === 'presets') {
+        const presetsTab = document.getElementById('tab-presets');
+        const sections = presetsTab.querySelectorAll(
+          '.settings-section, .preset-pagination',
+        );
+        sections.forEach((s) => (s.style.display = 'none'));
+        const spinner = document.createElement('div');
+        spinner.className = 'spinner';
+        presetsTab.appendChild(spinner);
+        await loadPresets();
+        spinner.remove();
+        sections.forEach((s) => (s.style.display = ''));
+      }
+
+      if (tabName === 'plugins') {
+        const pluginsTab = document.getElementById('tab-plugins');
+        const listView = document.getElementById('plugin-list-view');
+        listView.style.display = 'none';
         document.getElementById('plugin-detail-view').style.display = 'none';
-        document.getElementById('plugin-detail-actions').style.display = 'none';
+        const spinner = document.createElement('div');
+        spinner.className = 'spinner';
+        pluginsTab.appendChild(spinner);
+        await loadPlugins();
+        spinner.remove();
+      }
     });
+  });
 
-    const closeModal = () => {
-        const changesSaved = modal.dataset.changesSaved === 'true';
-        if (changesSaved) {
-            location.reload();
-        } else {
-            modal.classList.remove('open');
-        }
-    };
+  saveBtn.addEventListener('click', async () => {
+    await saveConfig();
+  });
 
-    closeBtn.addEventListener('click', closeModal);
-    cancelBtn.addEventListener('click', closeModal);
+  // Task pagination buttons
+  document
+    .getElementById('task-page-prev')
+    .addEventListener('click', () => loadTasks(taskPage - 1));
+  document
+    .getElementById('task-page-next')
+    .addEventListener('click', () => loadTasks(taskPage + 1));
 
-    modal.addEventListener('click', (e) => {
-        if (e.target === modal) {
-            closeModal();
-        }
-    });
+  // Preset pagination buttons
+  document
+    .getElementById('preset-page-prev')
+    .addEventListener('click', () => loadPresets(presetPage - 1));
+  document
+    .getElementById('preset-page-next')
+    .addEventListener('click', () => loadPresets(presetPage + 1));
 
-    document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && modal.classList.contains('open')) {
-            closeModal();
-        }
-    });
+  // Plugin pagination buttons
+  document
+    .getElementById('plugin-page-prev')
+    .addEventListener('click', () => loadPlugins(pluginPage - 1));
+  document
+    .getElementById('plugin-page-next')
+    .addEventListener('click', () => loadPlugins(pluginPage + 1));
 
-    tabBtns.forEach(btn => {
-        btn.addEventListener('click', async () => {
-            const tabName = btn.dataset.tab;
-            
-            tabBtns.forEach(b => b.classList.remove('active'));
-            btn.classList.add('active');
-            
-            document.querySelectorAll('.tab-content').forEach(content => {
-                content.classList.remove('active');
-            });
-            document.getElementById(`tab-${tabName}`).classList.add('active');
-
-            // Always restore main action buttons and hide plugin detail when switching tabs
-            document.getElementById('main-actions').style.display = '';
-            document.getElementById('plugin-detail-actions').style.display = 'none';
-            document.getElementById('plugin-detail-view').style.display = 'none';
-
-            if (tabName === 'tasks') {
-                const taskTab = document.getElementById('tab-tasks');
-                const sections = taskTab.querySelectorAll('.settings-section, .task-pagination');
-                sections.forEach(s => s.style.display = 'none');
-                const spinner = document.createElement('div');
-                spinner.className = 'spinner';
-                taskTab.appendChild(spinner);
-                await loadTasks();
-                spinner.remove();
-                sections.forEach(s => s.style.display = '');
-            }
-
-            if (tabName === 'presets') {
-                const presetsTab = document.getElementById('tab-presets');
-                const sections = presetsTab.querySelectorAll('.settings-section, .preset-pagination');
-                sections.forEach(s => s.style.display = 'none');
-                const spinner = document.createElement('div');
-                spinner.className = 'spinner';
-                presetsTab.appendChild(spinner);
-                await loadPresets();
-                spinner.remove();
-                sections.forEach(s => s.style.display = '');
-            }
-
-            if (tabName === 'plugins') {
-                const pluginsTab = document.getElementById('tab-plugins');
-                const listView = document.getElementById('plugin-list-view');
-                listView.style.display = 'none';
-                document.getElementById('plugin-detail-view').style.display = 'none';
-                const spinner = document.createElement('div');
-                spinner.className = 'spinner';
-                pluginsTab.appendChild(spinner);
-                await loadPlugins();
-                spinner.remove();
-            }
-        });
-    });
-
-    saveBtn.addEventListener('click', async () => {
-        await saveConfig();
-    });
-
-    // Task pagination buttons
-    document.getElementById('task-page-prev').addEventListener('click', () => loadTasks(taskPage - 1));
-    document.getElementById('task-page-next').addEventListener('click', () => loadTasks(taskPage + 1));
-
-    // Preset pagination buttons
-    document.getElementById('preset-page-prev').addEventListener('click', () => loadPresets(presetPage - 1));
-    document.getElementById('preset-page-next').addEventListener('click', () => loadPresets(presetPage + 1));
-
-    // Plugin pagination buttons
-    document.getElementById('plugin-page-prev').addEventListener('click', () => loadPlugins(pluginPage - 1));
-    document.getElementById('plugin-page-next').addEventListener('click', () => loadPlugins(pluginPage + 1));
-
-    // Library maintenance buttons
-    document.getElementById('task-reset-count').addEventListener('click', () => {
-        startTask('reset_image_count');
-    });
-    document.getElementById('task-clear-cache').addEventListener('click', () => {
-        startTask('clear_cache');
-    });
-    document.getElementById('task-rescan-library').addEventListener('click', () => {
-        startTask('rescan_library');
+  // Library maintenance buttons
+  document.getElementById('task-reset-count').addEventListener('click', () => {
+    startTask('reset_image_count');
+  });
+  document.getElementById('task-clear-cache').addEventListener('click', () => {
+    startTask('clear_cache');
+  });
+  document
+    .getElementById('task-rescan-library')
+    .addEventListener('click', () => {
+      startTask('rescan_library');
     });
 }

--- a/tests/javascript/config.test.js
+++ b/tests/javascript/config.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 function setupBottomBar() {
-    document.body.innerHTML = `
+  document.body.innerHTML = `
         <div id="bottom-bar">
             <div class="info-group" id="photo-date-group"><span id="photo-date"></span></div>
             <div class="group-separator"></div>
@@ -15,338 +15,365 @@ function setupBottomBar() {
 }
 
 function updateSeparators() {
-    const bottomBar = document.getElementById('bottom-bar');
-    const groups = bottomBar.querySelectorAll('.info-group');
-    const separators = bottomBar.querySelectorAll('.group-separator');
+  const bottomBar = document.getElementById('bottom-bar');
+  const groups = bottomBar.querySelectorAll('.info-group');
+  const separators = bottomBar.querySelectorAll('.group-separator');
 
-    separators.forEach(sep => sep.style.display = 'none');
+  separators.forEach((sep) => (sep.style.display = 'none'));
 
-    const visibleGroups = Array.from(groups).filter(g => g.style.display !== 'none');
-    visibleGroups.forEach((group, index) => {
-        if (index < visibleGroups.length - 1) {
-            const sep = group.nextElementSibling;
-            if (sep && sep.classList.contains('group-separator')) {
-                sep.style.display = '';
-            }
-        }
-    });
+  const visibleGroups = Array.from(groups).filter(
+    (g) => g.style.display !== 'none',
+  );
+  visibleGroups.forEach((group, index) => {
+    if (index < visibleGroups.length - 1) {
+      const sep = group.nextElementSibling;
+      if (sep && sep.classList.contains('group-separator')) {
+        sep.style.display = '';
+      }
+    }
+  });
 }
 
 describe('Config API Integration', () => {
-    beforeEach(() => {
-        global.fetch = vi.fn();
-        delete global.location;
-        global.location = { reload: vi.fn() };
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    delete global.location;
+    global.location = { reload: vi.fn() };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should call GET API to load config', async () => {
+    const mockConfig = {
+      id: 'test123',
+      display_date: true,
+      display_clock: false,
+      image_refresh_interval: 45000,
+      image_transition_interval: 15000,
+      image_zoom_effect: true,
+      image_transition_type: 'fade',
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockConfig,
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
+    const response = await fetch(
+      'http://localhost:8321/api/v1/configs/test123',
+    );
+    const config = await response.json();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8321/api/v1/configs/test123',
+    );
+    expect(config.display_date).toBe(true);
+    expect(config.display_clock).toBe(false);
+    expect(config.image_refresh_interval).toBe(45000);
+  });
+
+  it('should call PUT API to save config', async () => {
+    const configData = {
+      display_date: false,
+      display_clock: true,
+      image_refresh_interval: 60000,
+      image_transition_interval: 20000,
+      image_zoom_effect: false,
+      image_transition_type: 'zoom',
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => configData,
     });
 
-    it('should call GET API to load config', async () => {
-        const mockConfig = {
-            id: 'test123',
-            display_date: true,
-            display_clock: false,
-            image_refresh_interval: 45000,
-            image_transition_interval: 15000,
-            image_zoom_effect: true,
-            image_transition_type: 'fade'
-        };
-
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => mockConfig
-        });
-
-        const response = await fetch('http://localhost:8321/api/v1/configs/test123');
-        const config = await response.json();
-        
-        expect(global.fetch).toHaveBeenCalledWith('http://localhost:8321/api/v1/configs/test123');
-        expect(config.display_date).toBe(true);
-        expect(config.display_clock).toBe(false);
-        expect(config.image_refresh_interval).toBe(45000);
+    await fetch('http://localhost:8321/api/v1/configs/test123', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(configData),
     });
 
-    it('should call PUT API to save config', async () => {
-        const configData = {
-            display_date: false,
-            display_clock: true,
-            image_refresh_interval: 60000,
-            image_transition_interval: 20000,
-            image_zoom_effect: false,
-            image_transition_type: 'zoom'
-        };
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8321/api/v1/configs/test123',
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(configData),
+      },
+    );
+  });
 
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => configData
-        });
-        
-        await fetch('http://localhost:8321/api/v1/configs/test123', {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(configData)
-        });
+  it('should handle save error and show error message', async () => {
+    vi.useFakeTimers();
 
-        expect(global.fetch).toHaveBeenCalledWith(
-            'http://localhost:8321/api/v1/configs/test123',
-            {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(configData)
-            }
-        );
+    document.body.innerHTML =
+      '<div id="error-message" class="error-message"></div>';
+    const errorMessage = document.getElementById('error-message');
+
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
     });
 
-    it('should handle save error and show error message', async () => {
-        vi.useFakeTimers();
-        
-        document.body.innerHTML = '<div id="error-message" class="error-message"></div>';
-        const errorMessage = document.getElementById('error-message');
+    try {
+      const response = await fetch(
+        'http://localhost:8321/api/v1/configs/test123',
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        },
+      );
 
-        global.fetch.mockResolvedValueOnce({
-            ok: false,
-            status: 500
-        });
+      if (!response.ok) {
+        errorMessage.textContent = 'Failed to save settings. Please try again.';
+        errorMessage.classList.add('show');
 
-        try {
-            const response = await fetch('http://localhost:8321/api/v1/configs/test123', {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({})
-            });
+        setTimeout(() => {
+          errorMessage.classList.remove('show');
+        }, 3000);
+      }
+    } catch (error) {
+      // Error handled
+    }
 
-            if (!response.ok) {
-                errorMessage.textContent = 'Failed to save settings. Please try again.';
-                errorMessage.classList.add('show');
-                
-                setTimeout(() => {
-                    errorMessage.classList.remove('show');
-                }, 3000);
-            }
-        } catch (error) {
-            // Error handled
-        }
+    expect(errorMessage.textContent).toBe(
+      'Failed to save settings. Please try again.',
+    );
+    expect(errorMessage.classList.contains('show')).toBe(true);
 
-        expect(errorMessage.textContent).toBe('Failed to save settings. Please try again.');
-        expect(errorMessage.classList.contains('show')).toBe(true);
+    vi.advanceTimersByTime(3000);
+    expect(errorMessage.classList.contains('show')).toBe(false);
 
-        vi.advanceTimersByTime(3000);
-        expect(errorMessage.classList.contains('show')).toBe(false);
+    vi.useRealTimers();
+  });
 
-        vi.useRealTimers();
-    });
-
-    it('should keep modal open after successful save', async () => {
-        document.body.innerHTML = `
+  it('should keep modal open after successful save', async () => {
+    document.body.innerHTML = `
             <div id="settings-modal" data-config-id="test123" data-changes-saved="false">
                 <button id="cancel-settings" class="btn btn-secondary">Cancel</button>
             </div>
         `;
 
-        const modal = document.getElementById('settings-modal');
-        const cancelBtn = document.getElementById('cancel-settings');
+    const modal = document.getElementById('settings-modal');
+    const cancelBtn = document.getElementById('cancel-settings');
 
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({})
-        });
-
-        const response = await fetch('http://localhost:8321/api/v1/configs/test123', {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({})
-        });
-
-        if (response.ok) {
-            modal.dataset.changesSaved = 'true';
-            cancelBtn.textContent = 'Reload Now';
-            cancelBtn.classList.remove('btn-secondary');
-            cancelBtn.classList.add('btn-primary');
-        }
-
-        expect(modal.dataset.changesSaved).toBe('true');
-        expect(cancelBtn.textContent).toBe('Reload Now');
-        expect(cancelBtn.classList.contains('btn-primary')).toBe(true);
-        expect(cancelBtn.classList.contains('btn-secondary')).toBe(false);
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
     });
 
-    it('should reload page when closing modal after save', () => {
-        document.body.innerHTML = `
+    const response = await fetch(
+      'http://localhost:8321/api/v1/configs/test123',
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      },
+    );
+
+    if (response.ok) {
+      modal.dataset.changesSaved = 'true';
+      cancelBtn.textContent = 'Reload Now';
+      cancelBtn.classList.remove('btn-secondary');
+      cancelBtn.classList.add('btn-primary');
+    }
+
+    expect(modal.dataset.changesSaved).toBe('true');
+    expect(cancelBtn.textContent).toBe('Reload Now');
+    expect(cancelBtn.classList.contains('btn-primary')).toBe(true);
+    expect(cancelBtn.classList.contains('btn-secondary')).toBe(false);
+  });
+
+  it('should reload page when closing modal after save', () => {
+    document.body.innerHTML = `
             <div id="settings-modal" data-changes-saved="true" class="open"></div>
         `;
 
-        const modal = document.getElementById('settings-modal');
-        const changesSaved = modal.dataset.changesSaved === 'true';
+    const modal = document.getElementById('settings-modal');
+    const changesSaved = modal.dataset.changesSaved === 'true';
 
-        if (changesSaved) {
-            location.reload();
-        } else {
-            modal.classList.remove('open');
-        }
+    if (changesSaved) {
+      location.reload();
+    } else {
+      modal.classList.remove('open');
+    }
 
-        expect(location.reload).toHaveBeenCalled();
-    });
+    expect(location.reload).toHaveBeenCalled();
+  });
 
-    it('should not reload page when closing modal without save', () => {
-        document.body.innerHTML = `
+  it('should not reload page when closing modal without save', () => {
+    document.body.innerHTML = `
             <div id="settings-modal" data-changes-saved="false" class="open"></div>
         `;
 
-        const modal = document.getElementById('settings-modal');
-        const changesSaved = modal.dataset.changesSaved === 'true';
+    const modal = document.getElementById('settings-modal');
+    const changesSaved = modal.dataset.changesSaved === 'true';
 
-        if (changesSaved) {
-            location.reload();
-        } else {
-            modal.classList.remove('open');
-        }
+    if (changesSaved) {
+      location.reload();
+    } else {
+      modal.classList.remove('open');
+    }
 
-        expect(location.reload).not.toHaveBeenCalled();
-        expect(modal.classList.contains('open')).toBe(false);
-    });
+    expect(location.reload).not.toHaveBeenCalled();
+    expect(modal.classList.contains('open')).toBe(false);
+  });
 });
 
 describe('Bottom Bar Visibility', () => {
-    beforeEach(() => {
-        setupBottomBar();
-    });
+  beforeEach(() => {
+    setupBottomBar();
+  });
 
-    it('should hide photo date group when displayDate is false', () => {
-        document.getElementById('photo-date-group').style.display = 'none';
-        updateSeparators();
+  it('should hide photo date group when displayDate is false', () => {
+    document.getElementById('photo-date-group').style.display = 'none';
+    updateSeparators();
 
-        expect(document.getElementById('photo-date-group').style.display).toBe('none');
-    });
+    expect(document.getElementById('photo-date-group').style.display).toBe(
+      'none',
+    );
+  });
 
-    it('should hide clock groups when displayClock is false', () => {
-        document.getElementById('current-date-group').style.display = 'none';
-        document.getElementById('current-time-group').style.display = 'none';
-        updateSeparators();
+  it('should hide clock groups when displayClock is false', () => {
+    document.getElementById('current-date-group').style.display = 'none';
+    document.getElementById('current-time-group').style.display = 'none';
+    updateSeparators();
 
-        expect(document.getElementById('current-date-group').style.display).toBe('none');
-        expect(document.getElementById('current-time-group').style.display).toBe('none');
-    });
+    expect(document.getElementById('current-date-group').style.display).toBe(
+      'none',
+    );
+    expect(document.getElementById('current-time-group').style.display).toBe(
+      'none',
+    );
+  });
 
-    it('should hide separators between hidden groups', () => {
-        document.getElementById('photo-date-group').style.display = 'none';
-        document.getElementById('current-date-group').style.display = 'none';
-        document.getElementById('current-time-group').style.display = 'none';
-        updateSeparators();
+  it('should hide separators between hidden groups', () => {
+    document.getElementById('photo-date-group').style.display = 'none';
+    document.getElementById('current-date-group').style.display = 'none';
+    document.getElementById('current-time-group').style.display = 'none';
+    updateSeparators();
 
-        const separators = document.querySelectorAll('.group-separator');
-        const visibleSeps = Array.from(separators).filter(s => s.style.display !== 'none');
-        
-        // Only weather group visible, no separators needed
-        expect(visibleSeps.length).toBe(0);
-    });
+    const separators = document.querySelectorAll('.group-separator');
+    const visibleSeps = Array.from(separators).filter(
+      (s) => s.style.display !== 'none',
+    );
 
-    it('should show separator only between visible groups', () => {
-        document.getElementById('current-date-group').style.display = 'none';
-        document.getElementById('current-time-group').style.display = 'none';
-        updateSeparators();
+    // Only weather group visible, no separators needed
+    expect(visibleSeps.length).toBe(0);
+  });
 
-        const separators = document.querySelectorAll('.group-separator');
-        const visibleSeps = Array.from(separators).filter(s => s.style.display !== 'none');
-        
-        // photo-date and weather visible, one separator between them
-        expect(visibleSeps.length).toBe(1);
-    });
+  it('should show separator only between visible groups', () => {
+    document.getElementById('current-date-group').style.display = 'none';
+    document.getElementById('current-time-group').style.display = 'none';
+    updateSeparators();
 
-    it('should show all separators when all groups visible', () => {
-        updateSeparators();
+    const separators = document.querySelectorAll('.group-separator');
+    const visibleSeps = Array.from(separators).filter(
+      (s) => s.style.display !== 'none',
+    );
 
-        const separators = document.querySelectorAll('.group-separator');
-        const visibleSeps = Array.from(separators).filter(s => s.style.display !== 'none');
-        
-        expect(visibleSeps.length).toBe(3);
-    });
+    // photo-date and weather visible, one separator between them
+    expect(visibleSeps.length).toBe(1);
+  });
+
+  it('should show all separators when all groups visible', () => {
+    updateSeparators();
+
+    const separators = document.querySelectorAll('.group-separator');
+    const visibleSeps = Array.from(separators).filter(
+      (s) => s.style.display !== 'none',
+    );
+
+    expect(visibleSeps.length).toBe(3);
+  });
 });
 
 describe('Library Maintenance Tasks', () => {
-    beforeEach(() => {
-        global.fetch = vi.fn();
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should POST to create a task', async () => {
+    const mockTask = {
+      id: 'task123',
+      task_type: 'clear_cache',
+      status: 'pending',
+      progress: 0,
+      error: '',
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockTask,
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
+    const response = await fetch('http://localhost:8321/api/v1/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ task_type: 'clear_cache' }),
+    });
+    const task = await response.json();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8321/api/v1/tasks',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(task.task_type).toBe('clear_cache');
+    expect(task.status).toBe('pending');
+  });
+
+  it('should GET to poll task status', async () => {
+    const mockTask = {
+      id: 'task123',
+      task_type: 'rescan_library',
+      status: 'running',
+      progress: 50,
+      error: '',
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockTask,
     });
 
-    it('should POST to create a task', async () => {
-        const mockTask = {
-            id: 'task123',
-            task_type: 'clear_cache',
-            status: 'pending',
-            progress: 0,
-            error: ''
-        };
+    const response = await fetch('http://localhost:8321/api/v1/tasks/task123');
+    const task = await response.json();
 
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => mockTask
-        });
+    expect(task.status).toBe('running');
+    expect(task.progress).toBe(50);
+  });
 
-        const response = await fetch('http://localhost:8321/api/v1/tasks', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ task_type: 'clear_cache' })
-        });
-        const task = await response.json();
-
-        expect(global.fetch).toHaveBeenCalledWith(
-            'http://localhost:8321/api/v1/tasks',
-            expect.objectContaining({ method: 'POST' })
-        );
-        expect(task.task_type).toBe('clear_cache');
-        expect(task.status).toBe('pending');
+  it('should handle task creation failure', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
     });
 
-    it('should GET to poll task status', async () => {
-        const mockTask = {
-            id: 'task123',
-            task_type: 'rescan_library',
-            status: 'running',
-            progress: 50,
-            error: ''
-        };
-
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => mockTask
-        });
-
-        const response = await fetch('http://localhost:8321/api/v1/tasks/task123');
-        const task = await response.json();
-
-        expect(task.status).toBe('running');
-        expect(task.progress).toBe(50);
+    const response = await fetch('http://localhost:8321/api/v1/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ task_type: 'invalid' }),
     });
 
-    it('should handle task creation failure', async () => {
-        global.fetch.mockResolvedValueOnce({
-            ok: false,
-            status: 400
-        });
-
-        const response = await fetch('http://localhost:8321/api/v1/tasks', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ task_type: 'invalid' })
-        });
-
-        expect(response.ok).toBe(false);
-    });
+    expect(response.ok).toBe(false);
+  });
 });
 
 describe('Task Progress UI', () => {
-    beforeEach(() => {
-        global.fetch = vi.fn();
-        document.body.innerHTML = `
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    document.body.innerHTML = `
             <div class="task-toast" id="task-toast">
                 <span id="task-toast-text">Running...</span>
                 <div class="task-toast-track">
@@ -354,60 +381,62 @@ describe('Task Progress UI', () => {
                 </div>
             </div>
         `;
-    });
+  });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-    it('should show toast when task starts', async () => {
-        const toast = document.getElementById('task-toast');
-        toast.classList.add('show');
+  it('should show toast when task starts', async () => {
+    const toast = document.getElementById('task-toast');
+    toast.classList.add('show');
 
-        expect(toast.classList.contains('show')).toBe(true);
-    });
+    expect(toast.classList.contains('show')).toBe(true);
+  });
 
-    it('should update progress bar width from task response', () => {
-        const bar = document.getElementById('task-toast-bar');
-        const text = document.getElementById('task-toast-text');
+  it('should update progress bar width from task response', () => {
+    const bar = document.getElementById('task-toast-bar');
+    const text = document.getElementById('task-toast-text');
 
-        // Simulate poll response
-        const task = { status: 'running', progress: 75, error: '' };
-        bar.style.width = `${task.progress}%`;
-        text.textContent = `Running... ${task.progress}%`;
+    // Simulate poll response
+    const task = { status: 'running', progress: 75, error: '' };
+    bar.style.width = `${task.progress}%`;
+    text.textContent = `Running... ${task.progress}%`;
 
-        expect(bar.style.width).toBe('75%');
-        expect(text.textContent).toBe('Running... 75%');
-    });
+    expect(bar.style.width).toBe('75%');
+    expect(text.textContent).toBe('Running... 75%');
+  });
 
-    it('should show Done on completion', () => {
-        const text = document.getElementById('task-toast-text');
-        const task = { status: 'completed', progress: 100, error: '' };
+  it('should show Done on completion', () => {
+    const text = document.getElementById('task-toast-text');
+    const task = { status: 'completed', progress: 100, error: '' };
 
-        text.textContent = task.status === 'completed' ? 'Done!' : `Failed: ${task.error}`;
+    text.textContent =
+      task.status === 'completed' ? 'Done!' : `Failed: ${task.error}`;
 
-        expect(text.textContent).toBe('Done!');
-    });
+    expect(text.textContent).toBe('Done!');
+  });
 
-    it('should show error on failure', () => {
-        const text = document.getElementById('task-toast-text');
-        const task = { status: 'failed', progress: 30, error: 'Connection lost' };
+  it('should show error on failure', () => {
+    const text = document.getElementById('task-toast-text');
+    const task = { status: 'failed', progress: 30, error: 'Connection lost' };
 
-        text.textContent = task.status === 'completed' ? 'Done!' : `Failed: ${task.error}`;
+    text.textContent =
+      task.status === 'completed' ? 'Done!' : `Failed: ${task.error}`;
 
-        expect(text.textContent).toBe('Failed: Connection lost');
-    });
+    expect(text.textContent).toBe('Failed: Connection lost');
+  });
 
-    it('should hide toast after completion delay', () => {
-        vi.useFakeTimers();
-        const toast = document.getElementById('task-toast');
-        toast.classList.add('show');
+  it('should hide toast after completion delay', () => {
+    vi.useFakeTimers();
+    const toast = document.getElementById('task-toast');
+    toast.classList.add('show');
 
-        setTimeout(() => toast.classList.remove('show'), 3000);
+    setTimeout(() => toast.classList.remove('show'), 3000);
 
-        vi.advanceTimersByTime(3000);
-        expect(toast.classList.contains('show')).toBe(false);
+    vi.advanceTimersByTime(3000);
+    expect(toast.classList.contains('show')).toBe(false);
 
-        vi.useRealTimers();
-    });
+    vi.useRealTimers();
+  });
 });

--- a/tests/javascript/geolocation-handler.test.js
+++ b/tests/javascript/geolocation-handler.test.js
@@ -285,7 +285,8 @@ describe('Save prevention with invalid coordinates', () => {
     for (const el of inputs) {
       if (el.type === 'checkbox' || el.type === 'select-one') continue;
       if (!validateCoordinates(el.value)) {
-        errorMessage.textContent = 'Invalid coordinates. Use lat,long format (e.g. 40.7128,-74.0060)';
+        errorMessage.textContent =
+          'Invalid coordinates. Use lat,long format (e.g. 40.7128,-74.0060)';
         errorMessage.classList.add('show');
         saveBtn.disabled = true;
         return false;

--- a/tests/javascript/main.test.js
+++ b/tests/javascript/main.test.js
@@ -3,10 +3,17 @@ import { JSDOM } from 'jsdom';
 
 describe('main.js', () => {
   let window, document;
-  let buildApiUrl, getWindowDimensions, fadeInImage, getNextImage, applyTransition, getRandomTransition, startTask;
+  let buildApiUrl,
+    getWindowDimensions,
+    fadeInImage,
+    getNextImage,
+    applyTransition,
+    getRandomTransition,
+    startTask;
 
   beforeEach(async () => {
-    const dom = new JSDOM(`
+    const dom = new JSDOM(
+      `
       <!DOCTYPE html>
       <html>
         <body>
@@ -24,7 +31,9 @@ describe('main.js', () => {
           </div>
         </body>
       </html>
-    `, { url: 'http://localhost' });
+    `,
+      { url: 'http://localhost' },
+    );
 
     window = dom.window;
     document = window.document;
@@ -42,7 +51,7 @@ describe('main.js', () => {
       pluginSpotifyEnabled: false,
       weatherCurrentTemp: '72°F',
       imageZoomEffect: true,
-      imageTransitionType: 'fade'
+      imageTransitionType: 'fade',
     };
 
     // Import functions after setting up globals
@@ -64,7 +73,9 @@ describe('main.js', () => {
 
     it('handles endpoints with query params', () => {
       const url = buildApiUrl('images/next?width=1920&height=1080');
-      expect(url).toBe('http://localhost:8321/api/v1/images/next?width=1920&height=1080');
+      expect(url).toBe(
+        'http://localhost:8321/api/v1/images/next?width=1920&height=1080',
+      );
     });
   });
 
@@ -118,14 +129,14 @@ describe('main.js', () => {
 
       global.fetch = vi.fn(() =>
         Promise.resolve({
-          json: () => Promise.resolve({ id: 'test-123', url: '/test.jpg' })
-        })
+          json: () => Promise.resolve({ id: 'test-123', url: '/test.jpg' }),
+        }),
       );
 
       const result = await getNextImage();
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:8321/api/v1/images/next?width=1920&height=1080'
+        'http://localhost:8321/api/v1/images/next?width=1920&height=1080',
       );
       expect(result).toEqual({ id: 'test-123', url: '/test.jpg' });
     });
@@ -136,14 +147,14 @@ describe('main.js', () => {
       vi.useFakeTimers();
       const img = document.createElement('img');
       const result = applyTransition(img, 'fade');
-      
+
       expect(result).toBe('fade');
     });
 
     it('applies slide-left transition', () => {
       const img = document.createElement('img');
       const result = applyTransition(img, 'slide-left');
-      
+
       expect(result).toBe('slide-left');
       expect(img.style.animation).toContain('slideInLeft');
       expect(img.style.opacity).toBe('1');
@@ -152,7 +163,7 @@ describe('main.js', () => {
     it('applies slide-right transition', () => {
       const img = document.createElement('img');
       const result = applyTransition(img, 'slide-right');
-      
+
       expect(result).toBe('slide-right');
       expect(img.style.animation).toContain('slideInRight');
       expect(img.style.opacity).toBe('1');
@@ -161,7 +172,7 @@ describe('main.js', () => {
     it('applies zoom transition', () => {
       const img = document.createElement('img');
       const result = applyTransition(img, 'zoom');
-      
+
       expect(result).toBe('zoom');
       expect(img.style.animation).toContain('zoomInTransition');
       expect(img.style.opacity).toBe('1');
@@ -170,7 +181,7 @@ describe('main.js', () => {
     it('applies no transition when set to none', () => {
       const img = document.createElement('img');
       const result = applyTransition(img, 'none');
-      
+
       expect(result).toBe('none');
       expect(img.style.opacity).toBe('1');
     });
@@ -178,7 +189,7 @@ describe('main.js', () => {
     it('applies random transition', () => {
       const img = document.createElement('img');
       const result = applyTransition(img, 'random');
-      
+
       // Random should return one of the valid transitions
       expect(['fade', 'slide-left', 'slide-right', 'zoom']).toContain(result);
     });
@@ -203,15 +214,23 @@ describe('main.js', () => {
         Promise.resolve({
           ok: true,
           status: 201,
-          json: () => Promise.resolve({ id: 'task-1', task_type_label: 'Clear Cache', progress: 0, status: 'pending' })
-        })
+          json: () =>
+            Promise.resolve({
+              id: 'task-1',
+              task_type_label: 'Clear Cache',
+              progress: 0,
+              status: 'pending',
+            }),
+        }),
       );
 
       await startTask('clear_cache');
 
       const text = document.getElementById('task-toast-text');
       expect(text.textContent).toBe('Clear Cache 0%');
-      expect(document.getElementById('task-toast').classList.contains('show')).toBe(true);
+      expect(
+        document.getElementById('task-toast').classList.contains('show'),
+      ).toBe(true);
     });
 
     it('updates toast with label and percentage during polling', async () => {
@@ -220,13 +239,26 @@ describe('main.js', () => {
         callCount++;
         if (callCount === 1) {
           return Promise.resolve({
-            ok: true, status: 201,
-            json: () => Promise.resolve({ id: 'task-1', task_type_label: 'Rescan Library', progress: 0, status: 'pending' })
+            ok: true,
+            status: 201,
+            json: () =>
+              Promise.resolve({
+                id: 'task-1',
+                task_type_label: 'Rescan Library',
+                progress: 0,
+                status: 'pending',
+              }),
           });
         }
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ id: 'task-1', task_type_label: 'Rescan Library', progress: 50, status: 'running' })
+          json: () =>
+            Promise.resolve({
+              id: 'task-1',
+              task_type_label: 'Rescan Library',
+              progress: 50,
+              status: 'running',
+            }),
         });
       });
 
@@ -244,20 +276,35 @@ describe('main.js', () => {
         callCount++;
         if (callCount === 1) {
           return Promise.resolve({
-            ok: true, status: 201,
-            json: () => Promise.resolve({ id: 'task-1', task_type_label: 'Reset Image Count', progress: 0, status: 'pending' })
+            ok: true,
+            status: 201,
+            json: () =>
+              Promise.resolve({
+                id: 'task-1',
+                task_type_label: 'Reset Image Count',
+                progress: 0,
+                status: 'pending',
+              }),
           });
         }
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ id: 'task-1', task_type_label: 'Reset Image Count', progress: 100, status: 'completed' })
+          json: () =>
+            Promise.resolve({
+              id: 'task-1',
+              task_type_label: 'Reset Image Count',
+              progress: 100,
+              status: 'completed',
+            }),
         });
       });
 
       await startTask('reset_image_count');
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(document.getElementById('task-toast-text').textContent).toBe('Reset Image Count Done!');
+      expect(document.getElementById('task-toast-text').textContent).toBe(
+        'Reset Image Count Done!',
+      );
     });
 
     it('shows label with error on failure', async () => {
@@ -266,20 +313,36 @@ describe('main.js', () => {
         callCount++;
         if (callCount === 1) {
           return Promise.resolve({
-            ok: true, status: 201,
-            json: () => Promise.resolve({ id: 'task-1', task_type_label: 'Clear Cache', progress: 0, status: 'pending' })
+            ok: true,
+            status: 201,
+            json: () =>
+              Promise.resolve({
+                id: 'task-1',
+                task_type_label: 'Clear Cache',
+                progress: 0,
+                status: 'pending',
+              }),
           });
         }
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ id: 'task-1', task_type_label: 'Clear Cache', progress: 30, status: 'failed', error: 'disk full' })
+          json: () =>
+            Promise.resolve({
+              id: 'task-1',
+              task_type_label: 'Clear Cache',
+              progress: 30,
+              status: 'failed',
+              error: 'disk full',
+            }),
         });
       });
 
       await startTask('clear_cache');
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(document.getElementById('task-toast-text').textContent).toBe('Clear Cache Failed: disk full');
+      expect(document.getElementById('task-toast-text').textContent).toBe(
+        'Clear Cache Failed: disk full',
+      );
     });
 
     it('shows conflict message on 409', async () => {
@@ -287,15 +350,22 @@ describe('main.js', () => {
         Promise.resolve({
           ok: false,
           status: 409,
-          json: () => Promise.resolve({ detail: 'A Clear Cache task is already pending or running.' })
-        })
+          json: () =>
+            Promise.resolve({
+              detail: 'A Clear Cache task is already pending or running.',
+            }),
+        }),
       );
 
       const result = await startTask('clear_cache');
 
       expect(result).toBeNull();
-      expect(document.getElementById('task-toast-text').textContent).toBe('A Clear Cache task is already pending or running.');
-      expect(document.getElementById('task-toast').classList.contains('show')).toBe(true);
+      expect(document.getElementById('task-toast-text').textContent).toBe(
+        'A Clear Cache task is already pending or running.',
+      );
+      expect(
+        document.getElementById('task-toast').classList.contains('show'),
+      ).toBe(true);
     });
 
     it('shows generic error on network failure', async () => {
@@ -304,7 +374,9 @@ describe('main.js', () => {
       const result = await startTask('clear_cache');
 
       expect(result).toBeNull();
-      expect(document.getElementById('task-toast-text').textContent).toBe('Failed to start task');
+      expect(document.getElementById('task-toast-text').textContent).toBe(
+        'Failed to start task',
+      );
     });
   });
 });

--- a/tests/javascript/plugins.test.js
+++ b/tests/javascript/plugins.test.js
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 describe('Plugins Tab', () => {
-    beforeEach(() => {
-        global.fetch = vi.fn();
-        delete global.location;
-        global.location = { reload: vi.fn() };
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    delete global.location;
+    global.location = { reload: vi.fn() };
 
-        document.body.innerHTML = `
+    document.body.innerHTML = `
             <div id="settings-modal" data-config-id="abc123" data-config-name="custom-test" data-config-plugins='["weather"]'>
                 <div class="modal-tabs">
                     <button class="tab-btn active" data-tab="display">Display</button>
@@ -38,504 +38,645 @@ describe('Plugins Tab', () => {
             <button id="plugin-page-next" disabled></button>
         `;
 
-        global.window = Object.assign(global.window || {}, {
-            SMPL_CONFIG: {
-                host: 'http://localhost',
-                port: '8321',
-                refreshInterval: 30000,
-                transitionInterval: 10000,
-            }
-        });
+    global.window = Object.assign(global.window || {}, {
+      SMPL_CONFIG: {
+        host: 'http://localhost',
+        port: '8321',
+        refreshInterval: 30000,
+        transitionInterval: 10000,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should show list view and hide detail view on loadPlugins', async () => {
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
+    // Simulate detail view being open
+    document.getElementById('plugin-list-view').style.display = 'none';
+    document.getElementById('plugin-detail-view').style.display = '';
+
+    const { loadPlugins } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPlugins();
+
+    expect(document.getElementById('plugin-list-view').style.display).toBe('');
+    expect(document.getElementById('plugin-detail-view').style.display).toBe(
+      'none',
+    );
+  });
+
+  it('should restore main action buttons on loadPlugins', async () => {
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should show list view and hide detail view on loadPlugins', async () => {
-        const mockData = {
-            count: 1,
-            next: null,
-            previous: null,
-            results: [
-                { id: 'p1', name: 'weather', description: 'Weather data' },
-            ]
-        };
+    // Simulate main buttons hidden from detail view
+    document.getElementById('main-actions').style.display = 'none';
 
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockData),
-        });
+    const { loadPlugins } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPlugins();
 
-        // Simulate detail view being open
-        document.getElementById('plugin-list-view').style.display = 'none';
-        document.getElementById('plugin-detail-view').style.display = '';
+    expect(document.getElementById('main-actions').style.display).toBe('');
+  });
 
-        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPlugins();
+  it('should hide detail view after modal reopen', async () => {
+    // Simulate detail view left open
+    document.getElementById('plugin-detail-view').style.display = '';
+    document.getElementById('plugin-list-view').style.display = 'none';
 
-        expect(document.getElementById('plugin-list-view').style.display).toBe('');
-        expect(document.getElementById('plugin-detail-view').style.display).toBe('none');
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should restore main action buttons on loadPlugins', async () => {
-        const mockData = {
-            count: 1,
-            next: null,
-            previous: null,
-            results: [
-                { id: 'p1', name: 'weather', description: 'Weather data' },
-            ]
-        };
+    // loadPlugins should reset visibility (simulates what modal open triggers)
+    const { loadPlugins } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPlugins();
 
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockData),
-        });
+    expect(document.getElementById('plugin-detail-view').style.display).toBe(
+      'none',
+    );
+    expect(document.getElementById('plugin-list-view').style.display).toBe('');
+  });
 
-        // Simulate main buttons hidden from detail view
-        document.getElementById('main-actions').style.display = 'none';
+  it('should render plugin rows with toggle', async () => {
+    const mockData = {
+      count: 2,
+      next: null,
+      previous: null,
+      results: [
+        { id: 'p1', name: 'weather', description: 'Weather data' },
+        { id: 'p2', name: 'spotify', description: 'Now playing' },
+      ],
+    };
 
-        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPlugins();
-
-        expect(document.getElementById('main-actions').style.display).toBe('');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should hide detail view after modal reopen', async () => {
-        // Simulate detail view left open
-        document.getElementById('plugin-detail-view').style.display = '';
-        document.getElementById('plugin-list-view').style.display = 'none';
+    const { loadPlugins } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPlugins();
 
-        const mockData = {
-            count: 1,
-            next: null,
-            previous: null,
-            results: [
-                { id: 'p1', name: 'weather', description: 'Weather data' },
-            ]
-        };
+    const body = document.getElementById('plugin-list-body');
+    const rows = body.querySelectorAll('tr');
+    expect(rows.length).toBe(2);
 
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockData),
-        });
+    // Weather should be enabled (in configPlugins)
+    const weatherToggle = rows[0].querySelector('.plugin-toggle');
+    expect(weatherToggle.checked).toBe(true);
 
-        // loadPlugins should reset visibility (simulates what modal open triggers)
-        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPlugins();
+    // Spotify should be disabled (not in configPlugins)
+    const spotifyToggle = rows[1].querySelector('.plugin-toggle');
+    expect(spotifyToggle.checked).toBe(false);
+  });
 
-        expect(document.getElementById('plugin-detail-view').style.display).toBe('none');
-        expect(document.getElementById('plugin-list-view').style.display).toBe('');
+  it('should update configPlugins when toggle is changed', async () => {
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 'p1', name: 'spotify', description: 'Now playing' }],
+    };
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should render plugin rows with toggle', async () => {
-        const mockData = {
-            count: 2,
-            next: null,
-            previous: null,
-            results: [
-                { id: 'p1', name: 'weather', description: 'Weather data' },
-                { id: 'p2', name: 'spotify', description: 'Now playing' },
-            ]
-        };
+    const { loadPlugins } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPlugins();
 
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockData),
-        });
+    const modal = document.getElementById('settings-modal');
+    const toggle = document.querySelector('.plugin-toggle');
 
-        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPlugins();
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change'));
+    expect(JSON.parse(modal.dataset.configPlugins)).toContain('spotify');
 
-        const body = document.getElementById('plugin-list-body');
-        const rows = body.querySelectorAll('tr');
-        expect(rows.length).toBe(2);
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change'));
+    expect(JSON.parse(modal.dataset.configPlugins)).not.toContain('spotify');
+  });
 
-        // Weather should be enabled (in configPlugins)
-        const weatherToggle = rows[0].querySelector('.plugin-toggle');
-        expect(weatherToggle.checked).toBe(true);
-
-        // Spotify should be disabled (not in configPlugins)
-        const spotifyToggle = rows[1].querySelector('.plugin-toggle');
-        expect(spotifyToggle.checked).toBe(false);
+  it('should render configure button with correct plugin id', async () => {
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+    };
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should update configPlugins when toggle is changed', async () => {
-        const mockData = {
-            count: 1, next: null, previous: null,
-            results: [{ id: 'p1', name: 'spotify', description: 'Now playing' }]
-        };
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+    const { loadPlugins } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPlugins();
 
-        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPlugins();
+    const btn = document.querySelector('.plugin-configure-btn');
+    expect(btn).not.toBeNull();
+    expect(btn.dataset.id).toBe('p1');
+  });
 
-        const modal = document.getElementById('settings-modal');
-        const toggle = document.querySelector('.plugin-toggle');
+  it('should show error row when fetch fails', async () => {
+    global.fetch.mockRejectedValueOnce(new Error('Network error'));
 
-        toggle.checked = true;
-        toggle.dispatchEvent(new Event('change'));
-        expect(JSON.parse(modal.dataset.configPlugins)).toContain('spotify');
+    const { loadPlugins } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPlugins();
 
-        toggle.checked = false;
-        toggle.dispatchEvent(new Event('change'));
-        expect(JSON.parse(modal.dataset.configPlugins)).not.toContain('spotify');
+    const body = document.getElementById('plugin-list-body');
+    expect(body.innerHTML).toContain('Failed to load plugins');
+  });
+
+  it('should set pagination controls correctly', async () => {
+    const mockData = {
+      count: 8,
+      next: 'http://localhost/api/v1/plugins?page=2',
+      previous: null,
+      results: [
+        { id: 'p1', name: 'a', description: '' },
+        { id: 'p2', name: 'b', description: '' },
+        { id: 'p3', name: 'c', description: '' },
+        { id: 'p4', name: 'd', description: '' },
+        { id: 'p5', name: 'e', description: '' },
+      ],
+    };
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should render configure button with correct plugin id', async () => {
-        const mockData = {
-            count: 1, next: null, previous: null,
-            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
-        };
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+    const { loadPlugins } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPlugins();
 
-        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPlugins();
+    expect(document.getElementById('plugin-page-prev').disabled).toBe(true);
+    expect(document.getElementById('plugin-page-next').disabled).toBe(false);
+    expect(document.getElementById('plugin-page-info').textContent).toBe(
+      'Page 1 of 2',
+    );
+  });
 
-        const btn = document.querySelector('.plugin-configure-btn');
-        expect(btn).not.toBeNull();
-        expect(btn.dataset.id).toBe('p1');
+  it('should render form fields from settings schema in detail view', async () => {
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+    };
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should show error row when fetch fails', async () => {
-        global.fetch.mockRejectedValueOnce(new Error('Network error'));
+    const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+    await mod.loadPlugins();
 
-        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPlugins();
-
-        const body = document.getElementById('plugin-list-body');
-        expect(body.innerHTML).toContain('Failed to load plugins');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 'p1',
+          name: 'weather',
+          description: 'Weather data',
+          settings: { coords: '63.17,-147.46', temp_unit: 'F' },
+          settings_schema: [
+            { key: 'coords', label: 'Coordinates', type: 'text' },
+            {
+              key: 'temp_unit',
+              label: 'Temperature',
+              type: 'select',
+              options: ['F', 'C'],
+            },
+          ],
+        }),
     });
 
-    it('should set pagination controls correctly', async () => {
-        const mockData = {
-            count: 8, next: 'http://localhost/api/v1/plugins?page=2', previous: null,
-            results: [
-                { id: 'p1', name: 'a', description: '' },
-                { id: 'p2', name: 'b', description: '' },
-                { id: 'p3', name: 'c', description: '' },
-                { id: 'p4', name: 'd', description: '' },
-                { id: 'p5', name: 'e', description: '' },
-            ]
-        };
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+    const configBtn = document.querySelector('.plugin-configure-btn');
+    await configBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
 
-        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPlugins();
+    const form = document.getElementById('plugin-detail-form');
+    const inputs = form.querySelectorAll('.plugin-setting-input');
+    expect(inputs.length).toBe(2);
+    expect(inputs[0].dataset.key).toBe('coords');
+    expect(inputs[0].value).toBe('63.17,-147.46');
+    expect(inputs[1].dataset.key).toBe('temp_unit');
+    expect(inputs[1].value).toBe('F');
+  });
 
-        expect(document.getElementById('plugin-page-prev').disabled).toBe(true);
-        expect(document.getElementById('plugin-page-next').disabled).toBe(false);
-        expect(document.getElementById('plugin-page-info').textContent).toBe('Page 1 of 2');
+  it('should PUT plugin settings when detail save is clicked', async () => {
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+    };
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should render form fields from settings schema in detail view', async () => {
-        const mockData = {
-            count: 1, next: null, previous: null,
-            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
-        };
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+    const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+    await mod.loadPlugins();
 
-        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await mod.loadPlugins();
-
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve({
-                id: 'p1', name: 'weather', description: 'Weather data',
-                settings: { coords: '63.17,-147.46', temp_unit: 'F' },
-                settings_schema: [
-                    { key: 'coords', label: 'Coordinates', type: 'text' },
-                    { key: 'temp_unit', label: 'Temperature', type: 'select', options: ['F', 'C'] },
-                ]
-            }),
-        });
-
-        const configBtn = document.querySelector('.plugin-configure-btn');
-        await configBtn.click();
-        await new Promise(r => setTimeout(r, 0));
-
-        const form = document.getElementById('plugin-detail-form');
-        const inputs = form.querySelectorAll('.plugin-setting-input');
-        expect(inputs.length).toBe(2);
-        expect(inputs[0].dataset.key).toBe('coords');
-        expect(inputs[0].value).toBe('63.17,-147.46');
-        expect(inputs[1].dataset.key).toBe('temp_unit');
-        expect(inputs[1].value).toBe('F');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 'p1',
+          name: 'weather',
+          description: 'Weather data',
+          settings: { coords: '63.17,-147.46' },
+          settings_schema: [
+            { key: 'coords', label: 'Coordinates', type: 'text' },
+          ],
+        }),
     });
 
-    it('should PUT plugin settings when detail save is clicked', async () => {
-        const mockData = {
-            count: 1, next: null, previous: null,
-            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
-        };
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
+    const configBtn = document.querySelector('.plugin-configure-btn');
+    await configBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
 
-        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await mod.loadPlugins();
-
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve({
-                id: 'p1', name: 'weather', description: 'Weather data',
-                settings: { coords: '63.17,-147.46' },
-                settings_schema: [{ key: 'coords', label: 'Coordinates', type: 'text' }]
-            }),
-        });
-
-        const configBtn = document.querySelector('.plugin-configure-btn');
-        await configBtn.click();
-        await new Promise(r => setTimeout(r, 0));
-
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
-
-        const saveBtn = document.getElementById('plugin-detail-save');
-        await saveBtn.click();
-        await new Promise(r => setTimeout(r, 0));
-
-        const putCall = global.fetch.mock.calls.find(c => c[1] && c[1].method === 'PUT');
-        expect(putCall).toBeDefined();
-        const putBody = JSON.parse(putCall[1].body);
-        expect(putBody.settings.coords).toBe('63.17,-147.46');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
     });
 
-    it('should show Reload Now on cancel button after plugin detail save', async () => {
-        const mod = await enterPluginDetail();
+    const saveBtn = document.getElementById('plugin-detail-save');
+    await saveBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
 
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+    const putCall = global.fetch.mock.calls.find(
+      (c) => c[1] && c[1].method === 'PUT',
+    );
+    expect(putCall).toBeDefined();
+    const putBody = JSON.parse(putCall[1].body);
+    expect(putBody.settings.coords).toBe('63.17,-147.46');
+  });
 
-        const saveBtn = document.getElementById('plugin-detail-save');
-        await saveBtn.click();
-        await new Promise(r => setTimeout(r, 0));
+  it('should show Reload Now on cancel button after plugin detail save', async () => {
+    const mod = await enterPluginDetail();
 
-        const cancelBtn = document.getElementById('cancel-settings');
-        expect(cancelBtn.textContent).toBe('Reload Now');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
     });
 
-    it('should keep Back text on plugin back button after plugin detail save', async () => {
-        const mod = await enterPluginDetail();
+    const saveBtn = document.getElementById('plugin-detail-save');
+    await saveBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
 
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+    const cancelBtn = document.getElementById('cancel-settings');
+    expect(cancelBtn.textContent).toBe('Reload Now');
+  });
 
-        const saveBtn = document.getElementById('plugin-detail-save');
-        await saveBtn.click();
-        await new Promise(r => setTimeout(r, 0));
+  it('should keep Back text on plugin back button after plugin detail save', async () => {
+    const mod = await enterPluginDetail();
 
-        const backBtn = document.getElementById('plugin-detail-back');
-        expect(backBtn.textContent).toBe('Back');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
     });
 
-    it('should keep main action buttons visible when not in detail view', async () => {
-        const mockData = {
-            count: 1,
-            next: null,
-            previous: null,
-            results: [
-                { id: 'p1', name: 'weather', description: 'Weather data' },
-            ]
-        };
+    const saveBtn = document.getElementById('plugin-detail-save');
+    await saveBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
 
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockData),
-        });
+    const backBtn = document.getElementById('plugin-detail-back');
+    expect(backBtn.textContent).toBe('Back');
+  });
 
-        const { loadPlugins } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPlugins();
+  it('should keep main action buttons visible when not in detail view', async () => {
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+    };
 
-        // Main action buttons should always be visible in list view
-        expect(document.getElementById('main-actions').style.display).toBe('');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should hide main action buttons only when in detail view', async () => {
-        const mockData = {
-            count: 1,
-            next: null,
-            previous: null,
-            results: [
-                { id: 'p1', name: 'weather', description: 'Weather data',
-                  settings: {}, settings_schema: [] },
-            ]
-        };
+    const { loadPlugins } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPlugins();
 
-        // First load for loadPlugins
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockData),
-        });
+    // Main action buttons should always be visible in list view
+    expect(document.getElementById('main-actions').style.display).toBe('');
+  });
 
-        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await mod.loadPlugins();
+  it('should hide main action buttons only when in detail view', async () => {
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [
+        {
+          id: 'p1',
+          name: 'weather',
+          description: 'Weather data',
+          settings: {},
+          settings_schema: [],
+        },
+      ],
+    };
 
-        // Mock for openPluginDetail fetch
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve({
-                id: 'p1', name: 'weather', description: 'Weather data',
-                settings: {}, settings_schema: []
-            }),
-        });
-
-        // Click configure to open detail
-        const configBtn = document.querySelector('.plugin-configure-btn');
-        await configBtn.click();
-        await new Promise(r => setTimeout(r, 0));
-
-        // Main buttons should be hidden in detail view
-        expect(document.getElementById('main-actions').style.display).toBe('none');
-
-        // Mock for loadPlugins when clicking back
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockData),
-        });
-
-        // Click back
-        const backBtn = document.getElementById('plugin-detail-back');
-        await backBtn.click();
-        await new Promise(r => setTimeout(r, 0));
-
-        // Main buttons should be restored
-        expect(document.getElementById('main-actions').style.display).toBe('');
+    // First load for loadPlugins
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should show only main save button after navigating away from plugin detail', async () => {
-        const mockData = {
-            count: 1, next: null, previous: null,
-            results: [{ id: 'p1', name: 'weather', description: 'Weather data',
-                settings: {}, settings_schema: [] }]
-        };
+    const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+    await mod.loadPlugins();
 
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
-
-        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await mod.loadPlugins();
-
-        // Open detail view
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve({
-                id: 'p1', name: 'weather', description: 'Weather data',
-                settings: {}, settings_schema: []
-            }),
-        });
-        const configBtn = document.querySelector('.plugin-configure-btn');
-        await configBtn.click();
-        await new Promise(r => setTimeout(r, 0));
-
-        // Verify plugin detail actions are visible, main hidden
-        expect(document.getElementById('plugin-detail-actions').style.display).toBe('');
-        expect(document.getElementById('main-actions').style.display).toBe('none');
-
-        // Simulate navigating to another tab by calling loadPlugins (what tab click does)
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) });
-        await mod.loadPlugins();
-
-        // Only main actions should be visible, plugin detail actions hidden
-        expect(document.getElementById('main-actions').style.display).toBe('');
-        expect(document.getElementById('plugin-detail-actions').style.display).toBe('none');
-
-        // Only one save button should be visible
-        const mainActionsVisible = document.getElementById('main-actions').style.display !== 'none';
-        const pluginActionsHidden = document.getElementById('plugin-detail-actions').style.display === 'none';
-        expect(mainActionsVisible).toBe(true);
-        expect(pluginActionsHidden).toBe(true);
+    // Mock for openPluginDetail fetch
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 'p1',
+          name: 'weather',
+          description: 'Weather data',
+          settings: {},
+          settings_schema: [],
+        }),
     });
 
-    it('should show only main save after: open modal -> plugins -> configure -> display tab', async () => {
-        // This test was originally written to prove a bug where plugin-detail-actions
-        // stayed visible after switching tabs. The fix adds plugin detail cleanup to
-        // the tab handler. Now this test verifies the fix stays in place.
-        const mod = await enterPluginDetail();
-        simulateTabSwitch('display');
-        expect(document.getElementById('main-actions').style.display).toBe('');
-        expect(document.getElementById('plugin-detail-actions').style.display).toBe('none');
+    // Click configure to open detail
+    const configBtn = document.querySelector('.plugin-configure-btn');
+    await configBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Main buttons should be hidden in detail view
+    expect(document.getElementById('main-actions').style.display).toBe('none');
+
+    // Mock for loadPlugins when clicking back
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    // Helper to enter plugin detail view
-    async function enterPluginDetail() {
-        const pluginListData = {
-            count: 1, next: null, previous: null,
-            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
-        };
-        const pluginDetailData = {
-            id: 'p1', name: 'weather', description: 'Weather data',
-            settings: {}, settings_schema: []
-        };
+    // Click back
+    const backBtn = document.getElementById('plugin-detail-back');
+    await backBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
 
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(pluginListData) });
-        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await mod.loadPlugins();
+    // Main buttons should be restored
+    expect(document.getElementById('main-actions').style.display).toBe('');
+  });
 
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(pluginDetailData) });
-        const configBtn = document.querySelector('.plugin-configure-btn');
-        await configBtn.click();
-        await new Promise(r => setTimeout(r, 0));
+  it('should show only main save button after navigating away from plugin detail', async () => {
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [
+        {
+          id: 'p1',
+          name: 'weather',
+          description: 'Weather data',
+          settings: {},
+          settings_schema: [],
+        },
+      ],
+    };
 
-        expect(document.getElementById('plugin-detail-actions').style.display).toBe('');
-        expect(document.getElementById('main-actions').style.display).toBe('none');
-        return mod;
-    }
-
-    function simulateTabSwitch(tabName) {
-        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-        document.querySelector(`[data-tab="${tabName}"]`).classList.add('active');
-        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
-        document.getElementById(`tab-${tabName}`).classList.add('active');
-        document.getElementById('main-actions').style.display = '';
-        document.getElementById('plugin-detail-actions').style.display = 'none';
-        document.getElementById('plugin-detail-view').style.display = 'none';
-    }
-
-    it('should hide plugin actions after: configure -> click Back', async () => {
-        const mod = await enterPluginDetail();
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({
-            count: 1, next: null, previous: null,
-            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
-        })});
-        const backBtn = document.getElementById('plugin-detail-back');
-        await backBtn.click();
-        await new Promise(r => setTimeout(r, 0));
-        expect(document.getElementById('main-actions').style.display).toBe('');
-        expect(document.getElementById('plugin-detail-actions').style.display).toBe('none');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should hide plugin actions after: configure -> close modal -> reopen -> loadPlugins', async () => {
-        await enterPluginDetail();
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({
-            count: 1, next: null, previous: null,
-            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
-        })});
-        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await mod.loadPlugins();
-        expect(document.getElementById('main-actions').style.display).toBe('');
-        expect(document.getElementById('plugin-detail-actions').style.display).toBe('none');
-    });
+    const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+    await mod.loadPlugins();
 
-    it('should never show both action bars at the same time in detail view', async () => {
-        await enterPluginDetail();
-        const mainVisible = document.getElementById('main-actions').style.display !== 'none';
-        const pluginVisible = document.getElementById('plugin-detail-actions').style.display !== 'none';
-        expect(mainVisible && pluginVisible).toBe(false);
+    // Open detail view
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 'p1',
+          name: 'weather',
+          description: 'Weather data',
+          settings: {},
+          settings_schema: [],
+        }),
     });
+    const configBtn = document.querySelector('.plugin-configure-btn');
+    await configBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
 
-    it('should hide plugin detail view content when switching tabs from configure', async () => {
-        await enterPluginDetail();
-        expect(document.getElementById('plugin-detail-view').style.display).toBe('');
-        simulateTabSwitch('display');
-        expect(document.getElementById('plugin-detail-view').style.display).toBe('none');
-    });
+    // Verify plugin detail actions are visible, main hidden
+    expect(document.getElementById('plugin-detail-actions').style.display).toBe(
+      '',
+    );
+    expect(document.getElementById('main-actions').style.display).toBe('none');
 
-    it('should hide plugin actions after: configure -> switch to Plugins tab list', async () => {
-        const mod = await enterPluginDetail();
-        global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({
-            count: 1, next: null, previous: null,
-            results: [{ id: 'p1', name: 'weather', description: 'Weather data' }]
-        })});
-        await mod.loadPlugins();
-        expect(document.getElementById('main-actions').style.display).toBe('');
-        expect(document.getElementById('plugin-detail-actions').style.display).toBe('none');
-        expect(document.getElementById('plugin-list-view').style.display).toBe('');
-        expect(document.getElementById('plugin-detail-view').style.display).toBe('none');
+    // Simulate navigating to another tab by calling loadPlugins (what tab click does)
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
+    await mod.loadPlugins();
+
+    // Only main actions should be visible, plugin detail actions hidden
+    expect(document.getElementById('main-actions').style.display).toBe('');
+    expect(document.getElementById('plugin-detail-actions').style.display).toBe(
+      'none',
+    );
+
+    // Only one save button should be visible
+    const mainActionsVisible =
+      document.getElementById('main-actions').style.display !== 'none';
+    const pluginActionsHidden =
+      document.getElementById('plugin-detail-actions').style.display === 'none';
+    expect(mainActionsVisible).toBe(true);
+    expect(pluginActionsHidden).toBe(true);
+  });
+
+  it('should show only main save after: open modal -> plugins -> configure -> display tab', async () => {
+    // This test was originally written to prove a bug where plugin-detail-actions
+    // stayed visible after switching tabs. The fix adds plugin detail cleanup to
+    // the tab handler. Now this test verifies the fix stays in place.
+    const mod = await enterPluginDetail();
+    simulateTabSwitch('display');
+    expect(document.getElementById('main-actions').style.display).toBe('');
+    expect(document.getElementById('plugin-detail-actions').style.display).toBe(
+      'none',
+    );
+  });
+
+  // Helper to enter plugin detail view
+  async function enterPluginDetail() {
+    const pluginListData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+    };
+    const pluginDetailData = {
+      id: 'p1',
+      name: 'weather',
+      description: 'Weather data',
+      settings: {},
+      settings_schema: [],
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(pluginListData),
+    });
+    const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+    await mod.loadPlugins();
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(pluginDetailData),
+    });
+    const configBtn = document.querySelector('.plugin-configure-btn');
+    await configBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(document.getElementById('plugin-detail-actions').style.display).toBe(
+      '',
+    );
+    expect(document.getElementById('main-actions').style.display).toBe('none');
+    return mod;
+  }
+
+  function simulateTabSwitch(tabName) {
+    document
+      .querySelectorAll('.tab-btn')
+      .forEach((b) => b.classList.remove('active'));
+    document.querySelector(`[data-tab="${tabName}"]`).classList.add('active');
+    document
+      .querySelectorAll('.tab-content')
+      .forEach((c) => c.classList.remove('active'));
+    document.getElementById(`tab-${tabName}`).classList.add('active');
+    document.getElementById('main-actions').style.display = '';
+    document.getElementById('plugin-detail-actions').style.display = 'none';
+    document.getElementById('plugin-detail-view').style.display = 'none';
+  }
+
+  it('should hide plugin actions after: configure -> click Back', async () => {
+    const mod = await enterPluginDetail();
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          count: 1,
+          next: null,
+          previous: null,
+          results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+        }),
+    });
+    const backBtn = document.getElementById('plugin-detail-back');
+    await backBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(document.getElementById('main-actions').style.display).toBe('');
+    expect(document.getElementById('plugin-detail-actions').style.display).toBe(
+      'none',
+    );
+  });
+
+  it('should hide plugin actions after: configure -> close modal -> reopen -> loadPlugins', async () => {
+    await enterPluginDetail();
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          count: 1,
+          next: null,
+          previous: null,
+          results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+        }),
+    });
+    const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+    await mod.loadPlugins();
+    expect(document.getElementById('main-actions').style.display).toBe('');
+    expect(document.getElementById('plugin-detail-actions').style.display).toBe(
+      'none',
+    );
+  });
+
+  it('should never show both action bars at the same time in detail view', async () => {
+    await enterPluginDetail();
+    const mainVisible =
+      document.getElementById('main-actions').style.display !== 'none';
+    const pluginVisible =
+      document.getElementById('plugin-detail-actions').style.display !== 'none';
+    expect(mainVisible && pluginVisible).toBe(false);
+  });
+
+  it('should hide plugin detail view content when switching tabs from configure', async () => {
+    await enterPluginDetail();
+    expect(document.getElementById('plugin-detail-view').style.display).toBe(
+      '',
+    );
+    simulateTabSwitch('display');
+    expect(document.getElementById('plugin-detail-view').style.display).toBe(
+      'none',
+    );
+  });
+
+  it('should hide plugin actions after: configure -> switch to Plugins tab list', async () => {
+    const mod = await enterPluginDetail();
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          count: 1,
+          next: null,
+          previous: null,
+          results: [{ id: 'p1', name: 'weather', description: 'Weather data' }],
+        }),
+    });
+    await mod.loadPlugins();
+    expect(document.getElementById('main-actions').style.display).toBe('');
+    expect(document.getElementById('plugin-detail-actions').style.display).toBe(
+      'none',
+    );
+    expect(document.getElementById('plugin-list-view').style.display).toBe('');
+    expect(document.getElementById('plugin-detail-view').style.display).toBe(
+      'none',
+    );
+  });
 });

--- a/tests/javascript/presets.test.js
+++ b/tests/javascript/presets.test.js
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 describe('Presets Tab', () => {
-    beforeEach(() => {
-        global.fetch = vi.fn();
-        delete global.location;
-        global.location = { reload: vi.fn() };
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    delete global.location;
+    global.location = { reload: vi.fn() };
 
-        document.body.innerHTML = `
+    document.body.innerHTML = `
             <div id="settings-modal" data-config-id="abc123" data-config-name="smplFrm Default">
             </div>
             <table><tbody id="preset-list-body"></tbody></table>
@@ -15,171 +15,200 @@ describe('Presets Tab', () => {
             <button id="preset-page-next" disabled></button>
         `;
 
-        global.window = Object.assign(global.window || {}, {
-            SMPL_CONFIG: {
-                host: 'http://localhost',
-                port: '8321',
-                refreshInterval: 30000,
-                transitionInterval: 10000,
-            }
-        });
+    global.window = Object.assign(global.window || {}, {
+      SMPL_CONFIG: {
+        host: 'http://localhost',
+        port: '8321',
+        refreshInterval: 30000,
+        transitionInterval: 10000,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should load presets and render table rows', async () => {
+    const mockData = {
+      count: 2,
+      next: null,
+      previous: null,
+      results: [
+        {
+          id: 'p1',
+          name: 'smplFrm Default',
+          description: 'All display elements enabled',
+          is_active: true,
+        },
+        {
+          id: 'p2',
+          name: 'smplFrm Minimal',
+          description: 'Logo only, no overlays',
+          is_active: false,
+        },
+      ],
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
+    const { loadPresets } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPresets();
+
+    const body = document.getElementById('preset-list-body');
+    const rows = body.querySelectorAll('tr');
+    expect(rows.length).toBe(2);
+
+    // First row should have Active badge, no activate button
+    expect(rows[0].innerHTML).toContain('smplFrm Default');
+    expect(rows[0].innerHTML).toContain('All display elements enabled');
+    expect(rows[0].innerHTML).toContain('badge-active');
+    expect(rows[0].querySelector('.preset-activate-btn')).toBeNull();
+
+    // Second row should have activate button, no badge
+    expect(rows[1].innerHTML).toContain('smplFrm Minimal');
+    expect(rows[1].innerHTML).toContain('Logo only, no overlays');
+    expect(rows[1].innerHTML).not.toContain('badge-active');
+    expect(rows[1].querySelector('.preset-activate-btn')).not.toBeNull();
+
+    // Managed rows should not be editable
+    expect(rows[0].querySelector('[contenteditable]')).toBeNull();
+    expect(rows[1].querySelector('[contenteditable]')).toBeNull();
+  });
+
+  it('should make custom config name and description editable', async () => {
+    const mockData = {
+      count: 2,
+      next: null,
+      previous: null,
+      results: [
+        {
+          id: 'c1',
+          name: 'custom-20260101',
+          description: 'My config',
+          is_active: true,
+        },
+        {
+          id: 'p1',
+          name: 'smplFrm Default',
+          description: 'All display elements',
+          is_active: false,
+        },
+      ],
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should load presets and render table rows', async () => {
-        const mockData = {
-            count: 2,
-            next: null,
-            previous: null,
-            results: [
-                { id: 'p1', name: 'smplFrm Default', description: 'All display elements enabled', is_active: true },
-                { id: 'p2', name: 'smplFrm Minimal', description: 'Logo only, no overlays', is_active: false },
-            ]
-        };
+    const { loadPresets } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPresets();
 
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockData),
-        });
+    const body = document.getElementById('preset-list-body');
+    const rows = body.querySelectorAll('tr');
 
-        const { loadPresets } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPresets();
+    // Custom row should have editable cells
+    const editableCells = rows[0].querySelectorAll('[contenteditable]');
+    expect(editableCells.length).toBe(2);
+    expect(editableCells[0].dataset.field).toBe('name');
+    expect(editableCells[1].dataset.field).toBe('description');
 
-        const body = document.getElementById('preset-list-body');
-        const rows = body.querySelectorAll('tr');
-        expect(rows.length).toBe(2);
+    // Managed row should not have editable cells
+    expect(rows[1].querySelector('[contenteditable]')).toBeNull();
+  });
 
-        // First row should have Active badge, no activate button
-        expect(rows[0].innerHTML).toContain('smplFrm Default');
-        expect(rows[0].innerHTML).toContain('All display elements enabled');
-        expect(rows[0].innerHTML).toContain('badge-active');
-        expect(rows[0].querySelector('.preset-activate-btn')).toBeNull();
+  it('should call activate endpoint and reload on click', async () => {
+    const mockData = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 'p2', name: 'smplFrm Minimal', is_active: false }],
+    };
 
-        // Second row should have activate button, no badge
-        expect(rows[1].innerHTML).toContain('smplFrm Minimal');
-        expect(rows[1].innerHTML).toContain('Logo only, no overlays');
-        expect(rows[1].innerHTML).not.toContain('badge-active');
-        expect(rows[1].querySelector('.preset-activate-btn')).not.toBeNull();
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 'p2', is_active: true }),
+      });
 
-        // Managed rows should not be editable
-        expect(rows[0].querySelector('[contenteditable]')).toBeNull();
-        expect(rows[1].querySelector('[contenteditable]')).toBeNull();
+    const { loadPresets } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPresets();
+
+    const btn = document.querySelector('.preset-activate-btn');
+    await btn.click();
+
+    // Wait for async handler
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8321/api/v1/configs/p2/activate',
+      { method: 'POST' },
+    );
+    expect(global.location.reload).toHaveBeenCalled();
+  });
+
+  it('should show error row when fetch fails', async () => {
+    global.fetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const { loadPresets } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPresets();
+
+    const body = document.getElementById('preset-list-body');
+    expect(body.innerHTML).toContain('Failed to load presets');
+  });
+
+  it('should handle pagination controls', async () => {
+    const mockData = {
+      count: 8,
+      next: 'http://localhost:8321/api/v1/configs?page=2',
+      previous: null,
+      results: [
+        { id: 'p1', name: 'smplFrm Default', is_active: true },
+        { id: 'p2', name: 'smplFrm Minimal', is_active: false },
+        { id: 'p3', name: 'smplFrm Info', is_active: false },
+        { id: 'p4', name: 'smplFrm Media', is_active: false },
+        { id: 'p5', name: 'custom-20260101', is_active: false },
+      ],
+    };
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
     });
 
-    it('should make custom config name and description editable', async () => {
-        const mockData = {
-            count: 2,
-            next: null,
-            previous: null,
-            results: [
-                { id: 'c1', name: 'custom-20260101', description: 'My config', is_active: true },
-                { id: 'p1', name: 'smplFrm Default', description: 'All display elements', is_active: false },
-            ]
-        };
+    const { loadPresets } =
+      await import('../../src/smplfrm/smplfrm/static/main.js');
+    await loadPresets();
 
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockData),
-        });
+    const prev = document.getElementById('preset-page-prev');
+    const next = document.getElementById('preset-page-next');
+    const info = document.getElementById('preset-page-info');
 
-        const { loadPresets } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPresets();
-
-        const body = document.getElementById('preset-list-body');
-        const rows = body.querySelectorAll('tr');
-
-        // Custom row should have editable cells
-        const editableCells = rows[0].querySelectorAll('[contenteditable]');
-        expect(editableCells.length).toBe(2);
-        expect(editableCells[0].dataset.field).toBe('name');
-        expect(editableCells[1].dataset.field).toBe('description');
-
-        // Managed row should not have editable cells
-        expect(rows[1].querySelector('[contenteditable]')).toBeNull();
-    });
-
-    it('should call activate endpoint and reload on click', async () => {
-        const mockData = {
-            count: 1,
-            next: null,
-            previous: null,
-            results: [
-                { id: 'p2', name: 'smplFrm Minimal', is_active: false },
-            ]
-        };
-
-        global.fetch
-            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockData) })
-            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: 'p2', is_active: true }) });
-
-        const { loadPresets } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPresets();
-
-        const btn = document.querySelector('.preset-activate-btn');
-        await btn.click();
-
-        // Wait for async handler
-        await new Promise(r => setTimeout(r, 0));
-
-        expect(global.fetch).toHaveBeenCalledWith(
-            'http://localhost:8321/api/v1/configs/p2/activate',
-            { method: 'POST' }
-        );
-        expect(global.location.reload).toHaveBeenCalled();
-    });
-
-    it('should show error row when fetch fails', async () => {
-        global.fetch.mockRejectedValueOnce(new Error('Network error'));
-
-        const { loadPresets } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPresets();
-
-        const body = document.getElementById('preset-list-body');
-        expect(body.innerHTML).toContain('Failed to load presets');
-    });
-
-    it('should handle pagination controls', async () => {
-        const mockData = {
-            count: 8,
-            next: 'http://localhost:8321/api/v1/configs?page=2',
-            previous: null,
-            results: [
-                { id: 'p1', name: 'smplFrm Default', is_active: true },
-                { id: 'p2', name: 'smplFrm Minimal', is_active: false },
-                { id: 'p3', name: 'smplFrm Info', is_active: false },
-                { id: 'p4', name: 'smplFrm Media', is_active: false },
-                { id: 'p5', name: 'custom-20260101', is_active: false },
-            ]
-        };
-
-        global.fetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockData),
-        });
-
-        const { loadPresets } = await import('../../src/smplfrm/smplfrm/static/main.js');
-        await loadPresets();
-
-        const prev = document.getElementById('preset-page-prev');
-        const next = document.getElementById('preset-page-next');
-        const info = document.getElementById('preset-page-info');
-
-        expect(prev.disabled).toBe(true);
-        expect(next.disabled).toBe(false);
-        expect(info.textContent).toBe('Page 1 of 2');
-    });
+    expect(prev.disabled).toBe(true);
+    expect(next.disabled).toBe(false);
+    expect(info.textContent).toBe('Page 1 of 2');
+  });
 });
 
 describe('saveConfig copy-on-write', () => {
-    beforeEach(() => {
-        global.fetch = vi.fn();
-        delete global.location;
-        global.location = { reload: vi.fn() };
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    delete global.location;
+    global.location = { reload: vi.fn() };
 
-        document.body.innerHTML = `
+    document.body.innerHTML = `
             <div id="settings-modal" data-config-id="abc123" data-config-name="smplFrm Default" data-changes-saved="false" class="open">
                 <button id="cancel-settings" class="btn btn-secondary">Cancel</button>
                 <div id="error-message" class="error-message"></div>
@@ -193,36 +222,39 @@ describe('saveConfig copy-on-write', () => {
             <input type="number" id="setting-cache-timeout" value="300">
         `;
 
-        global.window = Object.assign(global.window || {}, {
-            SMPL_CONFIG: {
-                host: 'http://localhost',
-                port: '8321',
-                refreshInterval: 30000,
-                transitionInterval: 10000,
-            }
-        });
+    global.window = Object.assign(global.window || {}, {
+      SMPL_CONFIG: {
+        host: 'http://localhost',
+        port: '8321',
+        refreshInterval: 30000,
+        transitionInterval: 10000,
+      },
     });
+  });
 
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-    it('should call apply before PUT when active config is system-managed', async () => {
-        const newConfig = { id: 'new123', name: 'custom-20260324' };
+  it('should call apply before PUT when active config is system-managed', async () => {
+    const newConfig = { id: 'new123', name: 'custom-20260324' };
 
-        global.fetch
-            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(newConfig) })
-            .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(newConfig),
+      })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
 
-        // Dynamic import to get saveConfig — it's not exported, so we test via the module
-        // We need to call it indirectly. Let's just verify the fetch calls.
-        const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
+    // Dynamic import to get saveConfig — it's not exported, so we test via the module
+    // We need to call it indirectly. Let's just verify the fetch calls.
+    const mod = await import('../../src/smplfrm/smplfrm/static/main.js');
 
-        // saveConfig is not exported, but we can verify the pattern by checking
-        // that when we simulate the save flow, apply is called first
-        // For now, verify the modal data attributes are set correctly
-        const modal = document.getElementById('settings-modal');
-        expect(modal.dataset.configName).toBe('smplFrm Default');
-        expect(modal.dataset.configName.startsWith('smplFrm ')).toBe(true);
-    });
+    // saveConfig is not exported, but we can verify the pattern by checking
+    // that when we simulate the save flow, apply is called first
+    // For now, verify the modal data attributes are set correctly
+    const modal = document.getElementById('settings-modal');
+    expect(modal.dataset.configName).toBe('smplFrm Default');
+    expect(modal.dataset.configName.startsWith('smplFrm ')).toBe(true);
+  });
 });

--- a/tests/javascript/spotifyBar.test.js
+++ b/tests/javascript/spotifyBar.test.js
@@ -8,7 +8,8 @@ describe('spotify bar visibility', () => {
   let document, getNowPlaying;
 
   function setupDOM() {
-    const dom = new JSDOM(`
+    const dom = new JSDOM(
+      `
       <!DOCTYPE html>
       <html><body>
         <div id="spotify-bar" style="display: none;">
@@ -32,7 +33,9 @@ describe('spotify bar visibility', () => {
           <div class="task-toast-track"><div class="task-toast-bar" id="task-toast-bar"></div></div>
         </div>
       </body></html>
-    `, { url: 'http://localhost' });
+    `,
+      { url: 'http://localhost' },
+    );
 
     global.window = dom.window;
     global.document = dom.window.document;
@@ -40,11 +43,15 @@ describe('spotify bar visibility', () => {
     document = dom.window.document;
 
     dom.window.SMPL_CONFIG = {
-      transitionInterval: 1000, refreshInterval: 3000,
-      host: 'http://localhost', port: '8321',
-      displayDate: false, displayClock: false,
-      imageZoomEffect: false, imageTransitionType: 'fade',
-      plugins: ['spotify']
+      transitionInterval: 1000,
+      refreshInterval: 3000,
+      host: 'http://localhost',
+      port: '8321',
+      displayDate: false,
+      displayClock: false,
+      imageZoomEffect: false,
+      imageTransitionType: 'fade',
+      plugins: ['spotify'],
     };
   }
 
@@ -63,10 +70,12 @@ describe('spotify bar visibility', () => {
 
   it('shows spotify bar with now playing data after fetch', async () => {
     setupDOM();
-    global.fetch = vi.fn(() => Promise.resolve({
-      ok: true,
-      json: () => Promise.resolve({ artist: 'Artist', song: 'Song' })
-    }));
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ artist: 'Artist', song: 'Song' }),
+      }),
+    );
     const module = await import('../../src/smplfrm/smplfrm/static/main.js');
     getNowPlaying = module.getNowPlaying;
 
@@ -74,14 +83,23 @@ describe('spotify bar visibility', () => {
 
     const bar = document.getElementById('spotify-bar');
     expect(bar.style.display).toBe('flex');
-    expect(document.getElementById('spotify-now-playing').innerHTML).toContain('Artist');
+    expect(document.getElementById('spotify-now-playing').innerHTML).toContain(
+      'Artist',
+    );
   });
 
   it('shows spotify bar with oauth link when not authenticated', async () => {
     setupDOM();
-    global.fetch = vi.fn()
+    global.fetch = vi
+      .fn()
       .mockResolvedValueOnce({ ok: false })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ auth_url: 'https://accounts.spotify.com/authorize' }) });
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            auth_url: 'https://accounts.spotify.com/authorize',
+          }),
+      });
     const module = await import('../../src/smplfrm/smplfrm/static/main.js');
     getNowPlaying = module.getNowPlaying;
 
@@ -96,7 +114,8 @@ describe('spotify bar visibility', () => {
 
   it('shows spotify bar with icon on auth error', async () => {
     setupDOM();
-    global.fetch = vi.fn()
+    global.fetch = vi
+      .fn()
       .mockResolvedValueOnce({ ok: false })
       .mockResolvedValueOnce({ ok: false });
     const module = await import('../../src/smplfrm/smplfrm/static/main.js');

--- a/tests/javascript/tooltips.test.js
+++ b/tests/javascript/tooltips.test.js
@@ -7,9 +7,14 @@ describe('settings modal tooltips', () => {
   let document;
 
   beforeAll(() => {
-    const templatePath = resolve(__dirname, '../../src/smplfrm/smplfrm/templates/index.html');
+    const templatePath = resolve(
+      __dirname,
+      '../../src/smplfrm/smplfrm/templates/index.html',
+    );
     // Strip Django template tags so JSDOM can parse the HTML
-    const raw = readFileSync(templatePath, 'utf-8').replace(/\{%.*?%\}/g, '').replace(/\{\{.*?\}\}/g, '');
+    const raw = readFileSync(templatePath, 'utf-8')
+      .replace(/\{%.*?%\}/g, '')
+      .replace(/\{\{.*?\}\}/g, '');
     const dom = new JSDOM(raw);
     document = dom.window.document;
   });
@@ -41,10 +46,16 @@ describe('settings modal tooltips', () => {
       it(`${tabId} label "${labelText}" has a title attribute`, () => {
         const tab = document.getElementById(tabId);
         const label = Array.from(tab.querySelectorAll('label')).find(
-          (el) => el.textContent.trim() === labelText
+          (el) => el.textContent.trim() === labelText,
         );
-        expect(label, `label "${labelText}" not found in #${tabId}`).toBeTruthy();
-        expect(label.getAttribute('title'), `label "${labelText}" missing title`).toBeTruthy();
+        expect(
+          label,
+          `label "${labelText}" not found in #${tabId}`,
+        ).toBeTruthy();
+        expect(
+          label.getAttribute('title'),
+          `label "${labelText}" missing title`,
+        ).toBeTruthy();
       });
     });
   });
@@ -60,10 +71,13 @@ describe('settings modal tooltips', () => {
       it(`${tabId} column header "${headerText}" has a title attribute`, () => {
         const tab = document.getElementById(tabId);
         const th = Array.from(tab.querySelectorAll('th')).find(
-          (el) => el.textContent.trim() === headerText
+          (el) => el.textContent.trim() === headerText,
         );
         expect(th, `th "${headerText}" not found in #${tabId}`).toBeTruthy();
-        expect(th.getAttribute('title'), `th "${headerText}" missing title`).toBeTruthy();
+        expect(
+          th.getAttribute('title'),
+          `th "${headerText}" missing title`,
+        ).toBeTruthy();
       });
     });
   });

--- a/tests/javascript/updateSeparators.test.js
+++ b/tests/javascript/updateSeparators.test.js
@@ -5,7 +5,8 @@ describe('updateSeparators', () => {
   let document, updateSeparators;
 
   function setupDOM(groupDisplayValues = {}) {
-    const dom = new JSDOM(`
+    const dom = new JSDOM(
+      `
       <!DOCTYPE html>
       <html><body>
         <div id="bottom-bar" class="text-box" style="display: none;">
@@ -24,7 +25,9 @@ describe('updateSeparators', () => {
           <div class="task-toast-track"><div class="task-toast-bar" id="task-toast-bar"></div></div>
         </div>
       </body></html>
-    `, { url: 'http://localhost' });
+    `,
+      { url: 'http://localhost' },
+    );
 
     global.window = dom.window;
     global.document = dom.window.document;
@@ -32,11 +35,15 @@ describe('updateSeparators', () => {
     document = dom.window.document;
 
     dom.window.SMPL_CONFIG = {
-      transitionInterval: 1000, refreshInterval: 3000,
-      host: 'http://localhost', port: '8321',
-      displayDate: true, displayClock: true,
-      imageZoomEffect: false, imageTransitionType: 'fade',
-      plugins: []
+      transitionInterval: 1000,
+      refreshInterval: 3000,
+      host: 'http://localhost',
+      port: '8321',
+      displayDate: true,
+      displayClock: true,
+      imageZoomEffect: false,
+      imageTransitionType: 'fade',
+      plugins: [],
     };
 
     // Apply group visibility before importing
@@ -104,7 +111,7 @@ describe('updateSeparators', () => {
     updateSeparators();
 
     const separators = document.querySelectorAll('.group-separator');
-    separators.forEach(sep => {
+    separators.forEach((sep) => {
       expect(sep.style.display).toBe('none');
     });
   });
@@ -127,7 +134,9 @@ describe('updateSeparators', () => {
 
     // Other separators should be hidden
     const allSeps = document.querySelectorAll('.group-separator');
-    const visibleSeps = Array.from(allSeps).filter(s => s.style.display !== 'none');
+    const visibleSeps = Array.from(allSeps).filter(
+      (s) => s.style.display !== 'none',
+    );
     expect(visibleSeps.length).toBe(1);
   });
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json-summary', 'html'],
       include: ['src/smplfrm/smplfrm/static/**/*.js'],
-      exclude: ['**/*.test.js']
-    }
-  }
+      exclude: ['**/*.test.js'],
+    },
+  },
 });


### PR DESCRIPTION
## Summary

Adds ESLint and Prettier tooling for JavaScript files and applies an initial one-time format across the codebase.

Closes #170

## Changes

**Commit 1 — `chore: add ESLint + Prettier config and dependencies`**
- Added `.prettierrc` (single quotes, trailing commas)
- Added `eslint.config.js` with flat config targeting `src/**/static/**/*.js`, test files, and `vitest.config.js`
- Uses `eslint-config-prettier` to disable formatting rules that conflict with Prettier
- Added `lint`, `lint:fix`, `format`, and `format:check` npm scripts
- Pinned new devDependencies: `eslint@10.2.1`, `eslint-config-prettier@10.1.8`, `globals@17.5.0`, `prettier@3.8.3`

**Commit 2 — `style: one-time Prettier format of all JS files`**
- Formatted `main.js`, all test files, `eslint.config.js`, and `vitest.config.js` with Prettier
- No logic changes — purely whitespace, quotes, and trailing comma normalization

## What was tested

- Verified `npm run format:check` passes with no issues
- Verified `npm run lint` passes with no issues
- Verified existing JS tests still pass (`npm test`)