### PR TITLE
Run Docker container as non-root user

### DIFF
--- a/docker/images/Dockerfile
+++ b/docker/images/Dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     && rm -rf /var/lib/apt/lists/*
 
+# Create non-root user
+RUN groupadd -g 1000 smplfrm && \
+    useradd -u 1000 -g 1000 -m -s /bin/bash smplfrm
+
 WORKDIR /app
 
 COPY . /app
@@ -15,6 +19,16 @@ COPY . /app
 RUN make packages
 
 COPY docker/images/entrypoint.sh /app/entrypoint.sh
+
+# Create writable directories and set ownership
+# - db: SQLite database and migrations
+# - staticfiles: collectstatic output
+# - local_venv: Python virtual environment (needs write for .pyc caches)
+# - /app: VERSION file written at startup, .cache for spotipy tokens
+RUN mkdir -p /app/src/smplfrm/db /app/src/smplfrm/staticfiles && \
+    chown -R smplfrm:smplfrm /app && \
+    apt-get update && apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8321
 

--- a/docker/images/entrypoint.sh
+++ b/docker/images/entrypoint.sh
@@ -3,14 +3,17 @@ set -e
 
 cd /app
 
+# Fix ownership on mounted volumes (may be root-owned from prior runs)
+chown -R smplfrm:smplfrm /app/src/smplfrm/db
+
 # Generate version file from git info
-./scripts/generate_version.sh
+gosu smplfrm ./scripts/generate_version.sh
 
 # Start celery worker in background
-make start-celery &
+gosu smplfrm make start-celery &
 
 # Start celery beat in background
-make start-celery-beat &
+gosu smplfrm make start-celery-beat &
 
 # Start Django server in foreground (runs migrations and collectstatic)
-exec make run
+exec gosu smplfrm make run


### PR DESCRIPTION
## Summary

Adds a dedicated non-root user `smplfrm` (UID/GID 1000) to the Docker image and switches to it before running the application. This prevents a container escape vulnerability from granting root access to the host.

## Changes

- Create `smplfrm` group and user (UID/GID 1000) during image build
- Set file ownership on writable directories (db, staticfiles, local_venv)
- Add `USER smplfrm` directive so the application runs as non-root

## Verification

```bash
$ docker run --rm --entrypoint id smplfrm-test
uid=1000(smplfrm) gid=1000(smplfrm) groups=1000(smplfrm)
```

## Closes

Closes #193