### PR TITLE
Protect plugin secrets from exposure in API responses

### DIFF
--- a/src/smplfrm/smplfrm/tests/views/test_plugin_api.py
+++ b/src/smplfrm/smplfrm/tests/views/test_plugin_api.py
@@ -1,0 +1,158 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework import status
+
+from smplfrm.models import Plugin
+
+MOCK_REGISTRY = []
+
+
+def _setup_registry():
+    """Set up a mock plugin registry with a plugin that has secret fields."""
+    from smplfrm.plugins.base import BasePlugin
+
+    class FakePlugin(BasePlugin):
+        def __init__(self):
+            super().__init__(name="fake", description="Fake plugin")
+
+        def get_settings_schema(self):
+            return [
+                {"key": "api_key", "label": "API Key", "type": "password"},
+                {"key": "endpoint", "label": "Endpoint", "type": "text"},
+            ]
+
+    class NoSecretsPlugin(BasePlugin):
+        def __init__(self):
+            super().__init__(name="nosecrets", description="No secrets plugin")
+
+        def get_settings_schema(self):
+            return [
+                {"key": "color", "label": "Color", "type": "text"},
+            ]
+
+    MOCK_REGISTRY.clear()
+    MOCK_REGISTRY.append(FakePlugin)
+    MOCK_REGISTRY.append(NoSecretsPlugin)
+    return FakePlugin, NoSecretsPlugin
+
+
+class TestPluginSecretProtection(TestCase):
+    """Test that plugin secrets are masked in API responses."""
+
+    def setUp(self):
+        self.client = APIClient()
+        _setup_registry()
+        self.plugin = Plugin.objects.create(
+            name="fake",
+            description="Fake plugin",
+            settings={
+                "api_key": "super-secret-value",
+                "endpoint": "https://api.example.com",
+            },
+        )
+        self.no_secrets_plugin = Plugin.objects.create(
+            name="nosecrets",
+            description="No secrets plugin",
+            settings={"color": "blue"},
+        )
+
+    @patch(
+        "smplfrm.views.serializers.v1.plugin_serializer.PLUGIN_REGISTRY", MOCK_REGISTRY
+    )
+    def test_secret_fields_masked_in_detail_response(self):
+        """Secret fields should be replaced with '******' in GET responses."""
+        response = self.client.get(f"/api/v1/plugins/{self.plugin.external_id}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["settings"]["api_key"], "******")
+        self.assertEqual(
+            response.data["settings"]["endpoint"], "https://api.example.com"
+        )
+
+    @patch(
+        "smplfrm.views.serializers.v1.plugin_serializer.PLUGIN_REGISTRY", MOCK_REGISTRY
+    )
+    def test_secret_fields_masked_in_list_response(self):
+        """Secret fields should be masked in list responses too."""
+        response = self.client.get("/api/v1/plugins")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        fake_plugin = next(p for p in results if p["name"] == "fake")
+        self.assertEqual(fake_plugin["settings"]["api_key"], "******")
+        self.assertEqual(fake_plugin["settings"]["endpoint"], "https://api.example.com")
+
+    @patch(
+        "smplfrm.views.serializers.v1.plugin_serializer.PLUGIN_REGISTRY", MOCK_REGISTRY
+    )
+    def test_no_secrets_plugin_settings_unmodified(self):
+        """Plugins without secret fields should have settings returned as-is."""
+        response = self.client.get(
+            f"/api/v1/plugins/{self.no_secrets_plugin.external_id}"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["settings"]["color"], "blue")
+
+    @patch(
+        "smplfrm.views.serializers.v1.plugin_serializer.PLUGIN_REGISTRY", MOCK_REGISTRY
+    )
+    @patch("smplfrm.views.api.v1.plugins.PLUGIN_REGISTRY", MOCK_REGISTRY)
+    def test_update_with_real_secret_persists_value(self):
+        """Submitting a real secret value should persist it to the database."""
+        update_data = {
+            "settings": {
+                "api_key": "new-secret",
+                "endpoint": "https://new.example.com",
+            },
+        }
+
+        response = self.client.put(
+            f"/api/v1/plugins/{self.plugin.external_id}",
+            update_data,
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Response should mask the secret
+        self.assertEqual(response.data["settings"]["api_key"], "******")
+        self.assertEqual(
+            response.data["settings"]["endpoint"], "https://new.example.com"
+        )
+
+        # But the DB should have the real value
+        self.plugin.refresh_from_db()
+        self.assertEqual(self.plugin.settings["api_key"], "new-secret")
+
+    @patch(
+        "smplfrm.views.serializers.v1.plugin_serializer.PLUGIN_REGISTRY", MOCK_REGISTRY
+    )
+    @patch("smplfrm.views.api.v1.plugins.PLUGIN_REGISTRY", MOCK_REGISTRY)
+    def test_update_with_masked_placeholder_retains_original(self):
+        """Submitting '******' for a secret field should retain the stored value."""
+        update_data = {
+            "settings": {
+                "api_key": "******",
+                "endpoint": "https://changed.example.com",
+            },
+        }
+
+        response = self.client.put(
+            f"/api/v1/plugins/{self.plugin.external_id}",
+            update_data,
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data["settings"]["endpoint"], "https://changed.example.com"
+        )
+
+        # DB should retain the original secret, not the placeholder
+        self.plugin.refresh_from_db()
+        self.assertEqual(self.plugin.settings["api_key"], "super-secret-value")
+        self.assertEqual(
+            self.plugin.settings["endpoint"], "https://changed.example.com"
+        )

--- a/src/smplfrm/smplfrm/views/api/v1/plugins.py
+++ b/src/smplfrm/smplfrm/views/api/v1/plugins.py
@@ -4,8 +4,9 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 from smplfrm.models import Plugin
+from smplfrm.plugins import PLUGIN_REGISTRY
 from smplfrm.services.plugin_service import PluginService
-from smplfrm.views.serializers.v1.plugin_serializer import PluginSerializer
+from smplfrm.views.serializers.v1.plugin_serializer import PluginSerializer, SECRET_MASK
 
 
 class PluginPagination(PageNumberPagination):
@@ -35,11 +36,33 @@ class PluginViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
+    def _get_secret_keys(self, plugin_name):
+        """Return set of setting keys marked as type 'password' for a plugin."""
+        for cls in PLUGIN_REGISTRY:
+            plugin = cls()
+            if plugin.name == plugin_name:
+                return {
+                    field["key"]
+                    for field in plugin.get_settings_schema()
+                    if field.get("type") == "password"
+                }
+        return set()
+
     def update(self, request, *args, **kwargs):
         plugin = self.get_object()
         serializer = self.get_serializer(plugin, data=request.data)
         serializer.is_valid(raise_exception=True)
-        plugin.settings = serializer.validated_data.get("settings", plugin.settings)
+
+        new_settings = serializer.validated_data.get("settings", plugin.settings)
+
+        # Retain original secret values when the masked placeholder is submitted
+        secret_keys = self._get_secret_keys(plugin.name)
+        if secret_keys and new_settings:
+            for key in secret_keys:
+                if new_settings.get(key) == SECRET_MASK:
+                    new_settings[key] = plugin.settings.get(key, "")
+
+        plugin.settings = new_settings
         self.service.update(plugin)
         return Response(self.get_serializer(plugin).data)
 

--- a/src/smplfrm/smplfrm/views/serializers/v1/plugin_serializer.py
+++ b/src/smplfrm/smplfrm/views/serializers/v1/plugin_serializer.py
@@ -3,6 +3,8 @@ from rest_framework import serializers
 from smplfrm.models import Plugin
 from smplfrm.plugins import PLUGIN_REGISTRY
 
+SECRET_MASK = "******"
+
 
 class PluginSerializer(serializers.HyperlinkedModelSerializer):
 
@@ -26,3 +28,27 @@ class PluginSerializer(serializers.HyperlinkedModelSerializer):
             if plugin.name == obj.name:
                 return plugin.get_settings_schema()
         return []
+
+    def _get_secret_keys(self, plugin_name):
+        """Return set of setting keys marked as type 'password' for a plugin."""
+        for cls in PLUGIN_REGISTRY:
+            plugin = cls()
+            if plugin.name == plugin_name:
+                return {
+                    field["key"]
+                    for field in plugin.get_settings_schema()
+                    if field.get("type") == "password"
+                }
+        return set()
+
+    def to_representation(self, instance):
+        """Mask secret fields in the serialized output."""
+        data = super().to_representation(instance)
+        secret_keys = self._get_secret_keys(instance.name)
+        if secret_keys and data.get("settings"):
+            masked_settings = dict(data["settings"])
+            for key in secret_keys:
+                if key in masked_settings:
+                    masked_settings[key] = SECRET_MASK
+            data["settings"] = masked_settings
+        return data


### PR DESCRIPTION
## Summary

Plugin settings containing sensitive credentials (e.g., Spotify client_id/client_secret) were previously returned in plaintext via the API. This change masks secret fields in all responses and handles the round-trip case where the UI submits the masked placeholder back.

## Changes

- **PluginSerializer**: Added `to_representation` override that replaces settings fields with `type: password` in their schema with `"******"`
- **PluginViewSet**: When an update submits `"******"` for a secret field, the original stored value is retained instead of being overwritten
- **Tests**: 5 new tests covering masking in detail/list, real secret persistence, placeholder retention, and no-secrets passthrough

## How it works

1. Secret fields are identified by checking each plugin's `get_settings_schema()` for entries with `"type": "password"`
2. On read (GET): secret values are replaced with `"******"` in the response
3. On write (PUT): if the submitted value is `"******"`, the DB value is preserved; otherwise the new value is saved

## Test results

```
5 passed in 0.92s (new tests)
347 passed in 10.28s (full suite, no regressions)
```

## Closes

Closes #185