### PR TITLE
fix(docker): replace Django runserver with Gunicorn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,15 @@ packages-js-clean:
 run: staticfiles migrations
 	. ./local_venv/bin/activate; cd ./src/smplfrm;  $(PYTHON) manage.py runserver 0.0.0.0:8321
 
+run-gunicorn: staticfiles migrations
+	. ./local_venv/bin/activate; cd ./src/smplfrm; \
+	WORKERS=$$(python3.14 -c "import os; print(max(2, min(8, 2 * os.cpu_count() + 1)))"); \
+	gunicorn smplfrm.wsgi:application \
+		--bind 0.0.0.0:8321 \
+		--workers $$WORKERS \
+		--graceful-timeout 30 \
+		--timeout 30
+
 staticfiles:
 	. ./local_venv/bin/activate; cd ./src/smplfrm;  $(PYTHON) manage.py collectstatic --noinput
 

--- a/docker/images/entrypoint.sh
+++ b/docker/images/entrypoint.sh
@@ -15,5 +15,5 @@ gosu smplfrm make start-celery &
 # Start celery beat in background
 gosu smplfrm make start-celery-beat &
 
-# Start Django server in foreground (runs migrations and collectstatic)
-exec gosu smplfrm make run
+# Start Gunicorn in foreground (runs migrations and collectstatic first)
+exec gosu smplfrm make run-gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ django-redis~=6.0.0
 spotipy~=2.26.0
 pre-commit~=4.6.0
 whitenoise~=6.12.0
+gunicorn~=23.0.0


### PR DESCRIPTION
## Summary

Replaces Django's development server (`manage.py runserver`) with Gunicorn in the Docker container, addressing the security concern that the dev server is single-threaded, not hardened, and not intended for production use.

Closes #186

## Changes

- **requirements.txt**: Added `gunicorn~=23.0.0`
- **Makefile**: Added `run-gunicorn` target with dynamic worker calculation
- **docker/images/entrypoint.sh**: Switched from `make run` to `make run-gunicorn`

## Configuration

| Setting | Value |
|---------|-------|
| Workers | `max(2, min(8, 2 * CPU_cores + 1))` |
| Bind | `0.0.0.0:8321` |
| Graceful timeout | 30s (SIGTERM) |
| Worker timeout | 30s (force kill) |
| Static files | WhiteNoise (already configured) |

## Testing

- All 342 existing tests pass
- Gunicorn config validated with `--check-config`
- WSGI application loads correctly
- Worker calculation verified on multi-core system
- `make run` preserved for local development