### PR TITLE
feat(api): add global-bucket rate limiting

### DIFF
--- a/.kiro/steering/development-standards.md
+++ b/.kiro/steering/development-standards.md
@@ -28,6 +28,7 @@ inclusion: always
 ## Formatting and Linting
 - **DO NOT** run formatters or linters on file save — formatting is handled by a pre-commit git hook
 - **DO NOT** create or enable Kiro hooks that auto-format or auto-lint on save
+- **DO NOT** run lint or format commands as part of task execution — never run `black`, `ruff`, `eslint --fix`, `prettier --write`, or similar tools during implementation
 - The `.pre-commit-config.yaml` defines all formatting and linting rules; they run automatically at commit time
 
 ## File Management

--- a/docker/compose/config.env
+++ b/docker/compose/config.env
@@ -20,6 +20,11 @@ SMPL_FRM_PLUGINS_WEATHER_TEMP_UNIT = F
 SMPL_FRM_PLUGINS_WEATHER_PRECIP_UNIT = in
 SMPL_FRM_PLUGINS_WEATHER_WINDSPEED_UNIT = mph
 
+# API Rate Limiting (global bucket, shared across all clients)
+# SMPL_FRM_THROTTLE_ANON_RATE=60/minute
+# SMPL_FRM_THROTTLE_USER_RATE=120/minute
+# SMPL_FRM_THROTTLE_TASK_RATE=10/minute
+
 #Django
 # Generate a key: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
 DJANGO_SECRET_KEY=change-me

--- a/docs/Environment-Variables.md
+++ b/docs/Environment-Variables.md
@@ -37,6 +37,23 @@ Environment variables seed the initial configuration on first startup. After tha
 python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
 ```
 
+## Security
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `SMPL_FRM_THROTTLE_ANON_RATE` | `60/minute` | Global rate limit for anonymous API requests |
+| `SMPL_FRM_THROTTLE_USER_RATE` | `120/minute` | Global rate limit for authenticated API requests |
+| `SMPL_FRM_THROTTLE_TASK_RATE` | `10/minute` | Global rate limit for task creation endpoint |
+
+Format: `{number}/{period}` where period is `second`, `minute`, `hour`, or `day`.
+
+### Behavior notes
+
+- **Global bucket**: Rate limiting uses a single shared counter across all clients (not per-IP). All anonymous requests share one bucket, all authenticated requests share another, and all task creation requests share a third.
+- **HTTP 429 + Retry-After**: When a limit is exceeded, the API returns HTTP 429 (Too Many Requests) with a `Retry-After` header indicating the number of seconds to wait before retrying.
+- **Fail-open**: If Redis is unavailable, the throttle system allows requests through rather than blocking all traffic.
+- **Invalid value fallback**: If an environment variable contains an invalid format, the system falls back to the default rate and logs a warning. Check application logs for configuration warnings at startup.
+
 ## Plugins
 
 Plugin env vars use the prefix `SMPL_FRM_PLUGINS_{PLUGIN_NAME}_`. These override plugin DB settings on every startup.

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for local development scripts."""

--- a/scripts/utils/rate_limit_tester.py
+++ b/scripts/utils/rate_limit_tester.py
@@ -1,0 +1,309 @@
+"""Rate limit testing utilities for verifying throttle behavior.
+
+Provides reusable classes for hammering API endpoints and reporting
+whether rate limits are correctly enforced.
+
+Usage:
+    from scripts.utils.rate_limit_tester import (
+        AnonThrottleTester,
+        AuthThrottleTester,
+        TaskThrottleTester,
+    )
+
+    tester = AnonThrottleTester(base_url="http://localhost:8321")
+    result = tester.run()
+    result.print_report()
+"""
+
+import time
+from dataclasses import dataclass, field
+
+import requests
+
+
+@dataclass
+class ThrottleTestResult:
+    """Result of a throttle test run."""
+
+    name: str
+    endpoint: str
+    expected_limit: int
+    actual_successes: int
+    was_throttled: bool
+    retry_after: int | None = None
+    response_detail: str | None = None
+    content_type_ok: bool = False
+    issues: list[str] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        """Test passes if throttled and no response format issues."""
+        return self.was_throttled and len(self.issues) == 0
+
+    def print_report(self):
+        """Print a human-readable report of this test result."""
+        status = "PASS" if self.passed else "FAIL"
+        print(f"\n[{status}] {self.name}")
+        print(f"  Endpoint: {self.endpoint}")
+        print(f"  Expected limit: {self.expected_limit}/min")
+        print(f"  Actual successes before throttle: {self.actual_successes}")
+        print(f"  Was throttled: {self.was_throttled}")
+        if self.retry_after is not None:
+            print(f"  Retry-After: {self.retry_after}s")
+        if self.response_detail:
+            print(f"  Detail: {self.response_detail}")
+        if self.issues:
+            print(f"  Issues:")
+            for issue in self.issues:
+                print(f"    - {issue}")
+
+
+class BaseThrottleTester:
+    """Base class for throttle testing.
+
+    Subclasses define the endpoint, expected limit, and how to build requests.
+    """
+
+    name: str = "Base Throttle Test"
+    endpoint_path: str = "/api/v1/configs"
+    default_limit: int = 60
+
+    def __init__(
+        self, base_url: str = "http://localhost:8321", limit: int | None = None
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.limit = limit or self.default_limit
+        self.session = requests.Session()
+
+    @property
+    def url(self) -> str:
+        return f"{self.base_url}{self.endpoint_path}"
+
+    def setup_session(self):
+        """Override to configure auth headers or other session setup."""
+        pass
+
+    def make_request(self) -> requests.Response:
+        """Make a single request. Override for POST or custom methods."""
+        return self.session.get(self.url, timeout=10)
+
+    def validate_429(self, response: requests.Response) -> list[str]:
+        """Check that a 429 response has correct format."""
+        issues = []
+
+        # Retry-After header
+        if "Retry-After" not in response.headers:
+            issues.append("Missing Retry-After header")
+        else:
+            try:
+                val = int(response.headers["Retry-After"])
+                if val < 1:
+                    issues.append(f"Retry-After not positive: {val}")
+            except ValueError:
+                issues.append(
+                    f"Retry-After not an integer: {response.headers['Retry-After']}"
+                )
+
+        # Content-Type
+        content_type = response.headers.get("Content-Type", "")
+        if "application/json" not in content_type:
+            issues.append(f"Content-Type not JSON: {content_type}")
+
+        # Body
+        try:
+            body = response.json()
+            if "detail" not in body:
+                issues.append("Response body missing 'detail' field")
+        except Exception:
+            issues.append("Response body is not valid JSON")
+
+        return issues
+
+    def run(self, overshoot: int = 5) -> ThrottleTestResult:
+        """Send requests until throttled or limit+overshoot reached.
+
+        Args:
+            overshoot: Extra requests beyond the expected limit to send.
+
+        Returns:
+            ThrottleTestResult with all findings.
+        """
+        self.setup_session()
+        total = self.limit + overshoot
+        successes = 0
+        throttled_response = None
+
+        for i in range(total):
+            try:
+                resp = self.make_request()
+            except requests.RequestException as e:
+                return ThrottleTestResult(
+                    name=self.name,
+                    endpoint=self.url,
+                    expected_limit=self.limit,
+                    actual_successes=successes,
+                    was_throttled=False,
+                    issues=[f"Connection error on request #{i + 1}: {e}"],
+                )
+
+            if resp.status_code == 200:
+                successes += 1
+            elif resp.status_code == 429:
+                throttled_response = resp
+                break
+            else:
+                # Unexpected status — keep going but note it
+                pass
+
+        if throttled_response is None:
+            return ThrottleTestResult(
+                name=self.name,
+                endpoint=self.url,
+                expected_limit=self.limit,
+                actual_successes=successes,
+                was_throttled=False,
+                issues=[f"Sent {total} requests without being throttled"],
+            )
+
+        issues = self.validate_429(throttled_response)
+        retry_after = None
+        detail = None
+        content_type_ok = "application/json" in throttled_response.headers.get(
+            "Content-Type", ""
+        )
+
+        try:
+            retry_after = int(throttled_response.headers.get("Retry-After", "0"))
+        except ValueError:
+            pass
+
+        try:
+            detail = throttled_response.json().get("detail")
+        except Exception:
+            pass
+
+        return ThrottleTestResult(
+            name=self.name,
+            endpoint=self.url,
+            expected_limit=self.limit,
+            actual_successes=successes,
+            was_throttled=True,
+            retry_after=retry_after,
+            response_detail=detail,
+            content_type_ok=content_type_ok,
+            issues=issues,
+        )
+
+
+class AnonThrottleTester(BaseThrottleTester):
+    """Tests the anonymous global rate limit against a general endpoint."""
+
+    name = "Anonymous Global Throttle"
+    endpoint_path = "/api/v1/configs"
+    default_limit = 60
+
+
+class AuthThrottleTester(BaseThrottleTester):
+    """Tests the authenticated global rate limit.
+
+    Requires credentials to be provided for session setup.
+    """
+
+    name = "Authenticated Global Throttle"
+    endpoint_path = "/api/v1/configs"
+    default_limit = 120
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8321",
+        limit: int | None = None,
+        username: str = "",
+        password: str = "",
+        token: str = "",
+    ):
+        super().__init__(base_url, limit)
+        self.username = username
+        self.password = password
+        self.token = token
+
+    def setup_session(self):
+        """Configure session with auth credentials."""
+        if self.token:
+            self.session.headers["Authorization"] = f"Token {self.token}"
+        elif self.username and self.password:
+            self.session.auth = (self.username, self.password)
+
+
+class TaskThrottleTester(BaseThrottleTester):
+    """Tests the task endpoint's stricter rate limit."""
+
+    name = "Task Endpoint Throttle"
+    endpoint_path = "/api/v1/tasks"
+    default_limit = 10
+
+
+class RecoveryTester:
+    """Tests that rate limits recover after the window elapses.
+
+    WARNING: This test takes at least `wait_seconds` to complete.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8321",
+        wait_seconds: int = 65,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.wait_seconds = wait_seconds
+
+    def run(self) -> ThrottleTestResult:
+        """Exhaust the limit, wait, then verify recovery."""
+        # First exhaust the anonymous limit using a low-limit tester
+        tester = TaskThrottleTester(base_url=self.base_url)
+        exhaust_result = tester.run()
+
+        if not exhaust_result.was_throttled:
+            return ThrottleTestResult(
+                name="Rate Window Recovery",
+                endpoint=tester.url,
+                expected_limit=tester.limit,
+                actual_successes=0,
+                was_throttled=False,
+                issues=["Could not exhaust rate limit to test recovery"],
+            )
+
+        print(
+            f"  Rate limit exhausted. Waiting {self.wait_seconds}s for window reset..."
+        )
+        time.sleep(self.wait_seconds)
+
+        # Try again — should succeed
+        try:
+            resp = requests.get(tester.url, timeout=10)
+        except requests.RequestException as e:
+            return ThrottleTestResult(
+                name="Rate Window Recovery",
+                endpoint=tester.url,
+                expected_limit=tester.limit,
+                actual_successes=0,
+                was_throttled=True,
+                issues=[f"Connection error after wait: {e}"],
+            )
+
+        recovered = resp.status_code == 200
+        issues = (
+            []
+            if recovered
+            else [
+                f"Still throttled after {self.wait_seconds}s wait (HTTP {resp.status_code})"
+            ]
+        )
+
+        return ThrottleTestResult(
+            name="Rate Window Recovery",
+            endpoint=tester.url,
+            expected_limit=tester.limit,
+            actual_successes=1 if recovered else 0,
+            was_throttled=not recovered,
+            issues=issues,
+        )

--- a/scripts/verify_rate_limits.py
+++ b/scripts/verify_rate_limits.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Verify API rate limiting is working against a running smplFrm instance.
+
+Usage:
+    python scripts/verify_rate_limits.py [--host HOST] [--port PORT]
+
+Defaults to http://localhost:8321. Requires the server to be running.
+Uses the reusable tester classes from scripts/utils/rate_limit_tester.py.
+"""
+
+import argparse
+import sys
+import time
+
+import requests
+
+from utils.rate_limit_tester import (
+    AnonThrottleTester,
+    AuthThrottleTester,
+    TaskThrottleTester,
+    RecoveryTester,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify API rate limits on a running smplFrm instance"
+    )
+    parser.add_argument(
+        "--host", default="localhost", help="Server hostname (default: localhost)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=8321, help="Server port (default: 8321)"
+    )
+    parser.add_argument(
+        "--anon-limit",
+        type=int,
+        default=60,
+        help="Expected anonymous rate limit (default: 60)",
+    )
+    parser.add_argument(
+        "--task-limit",
+        type=int,
+        default=10,
+        help="Expected task rate limit (default: 10)",
+    )
+    parser.add_argument(
+        "--test-recovery",
+        action="store_true",
+        help="Include the recovery test (waits 65s+)",
+    )
+    args = parser.parse_args()
+
+    base_url = f"http://{args.host}:{args.port}"
+
+    print(f"Verifying rate limits against {base_url}")
+    print(f"Expected limits: anon={args.anon_limit}/min, task={args.task_limit}/min")
+
+    # Quick connectivity check
+    try:
+        resp = requests.get(f"{base_url}/api/v1/configs", timeout=5)
+        print(f"Server reachable (HTTP {resp.status_code})\n")
+    except requests.ConnectionError:
+        print(f"ERROR: Cannot connect to {base_url}. Is the server running?")
+        sys.exit(1)
+
+    results = []
+
+    # Task endpoint test first (lower limit, faster to verify)
+    print("=" * 60)
+    print("Running: Task Endpoint Throttle")
+    print("=" * 60)
+    task_tester = TaskThrottleTester(base_url=base_url, limit=args.task_limit)
+    task_result = task_tester.run()
+    task_result.print_report()
+    results.append(task_result)
+
+    # Wait to avoid cross-test interference
+    print("\n  Waiting 5s before next test...")
+    time.sleep(5)
+
+    # Anonymous throttle test
+    print("\n" + "=" * 60)
+    print("Running: Anonymous Global Throttle")
+    print("=" * 60)
+    anon_tester = AnonThrottleTester(base_url=base_url, limit=args.anon_limit)
+    anon_result = anon_tester.run()
+    anon_result.print_report()
+    results.append(anon_result)
+
+    # Recovery test (optional, takes 65s+)
+    if args.test_recovery:
+        print("\n  Waiting 5s before recovery test...")
+        time.sleep(5)
+        print("\n" + "=" * 60)
+        print("Running: Rate Window Recovery")
+        print("=" * 60)
+        recovery_tester = RecoveryTester(base_url=base_url)
+        recovery_result = recovery_tester.run()
+        recovery_result.print_report()
+        results.append(recovery_result)
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("SUMMARY")
+    print(f"{'='*60}")
+    passed = sum(1 for r in results if r.passed)
+    failed = sum(1 for r in results if not r.passed)
+
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        print(f"  [{status}] {r.name} — {r.actual_successes} requests before throttle")
+
+    print(f"\n  {passed} passed, {failed} failed")
+
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/smplfrm/conftest.py
+++ b/src/smplfrm/conftest.py
@@ -1,0 +1,16 @@
+"""Root conftest for smplfrm test suite.
+
+Clears the Django cache before each test to prevent throttle state
+from leaking between tests.
+"""
+
+import pytest
+from django.core.cache import cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Reset cache before each test so throttle counters don't leak."""
+    cache.clear()
+    yield
+    cache.clear()

--- a/src/smplfrm/smplfrm/settings.py
+++ b/src/smplfrm/smplfrm/settings.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 from celery.schedules import crontab
 
+from smplfrm.throttle_utils import parse_throttle_rate
+
 
 def _parse_bool_env(var_name: str, default: bool) -> bool:
     """Parse a boolean environment variable.
@@ -199,6 +201,30 @@ CACHES = {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
     }
+}
+
+
+# API Rate Limiting (global bucket throttling)
+SMPL_FRM_THROTTLE_ANON_RATE = parse_throttle_rate(
+    "SMPL_FRM_THROTTLE_ANON_RATE", "60/minute"
+)
+SMPL_FRM_THROTTLE_USER_RATE = parse_throttle_rate(
+    "SMPL_FRM_THROTTLE_USER_RATE", "120/minute"
+)
+SMPL_FRM_THROTTLE_TASK_RATE = parse_throttle_rate(
+    "SMPL_FRM_THROTTLE_TASK_RATE", "10/minute"
+)
+
+REST_FRAMEWORK = {
+    "DEFAULT_THROTTLE_CLASSES": [
+        "smplfrm.throttles.GlobalAnonThrottle",
+        "smplfrm.throttles.GlobalAuthenticatedThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "global_anon": SMPL_FRM_THROTTLE_ANON_RATE,
+        "global_authenticated": SMPL_FRM_THROTTLE_USER_RATE,
+        "global_task": SMPL_FRM_THROTTLE_TASK_RATE,
+    },
 }
 
 

--- a/src/smplfrm/smplfrm/tests/throttles/test_throttle_classes.py
+++ b/src/smplfrm/smplfrm/tests/throttles/test_throttle_classes.py
@@ -1,0 +1,210 @@
+"""
+Tests for custom throttle classes.
+
+Verifies that GlobalAnonThrottle, GlobalAuthenticatedThrottle, and
+GlobalTaskThrottle return correct cache keys based on request authentication
+status, use the expected scope names, and fail open when Redis is unavailable.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rest_framework.test import APIRequestFactory
+
+from smplfrm.throttles import (
+    GlobalAnonThrottle,
+    GlobalAuthenticatedThrottle,
+    GlobalTaskThrottle,
+)
+
+
+@pytest.fixture
+def factory():
+    """DRF API request factory."""
+    return APIRequestFactory()
+
+
+@pytest.fixture
+def anonymous_request(factory):
+    """A GET request with an anonymous (unauthenticated) user."""
+    request = factory.get("/api/v1/test/")
+    user = MagicMock()
+    user.is_authenticated = False
+    request.user = user
+    return request
+
+
+@pytest.fixture
+def authenticated_request(factory):
+    """A GET request with an authenticated user."""
+    request = factory.get("/api/v1/test/")
+    user = MagicMock()
+    user.is_authenticated = True
+    request.user = user
+    return request
+
+
+class TestGlobalAnonThrottleCacheKey:
+    """GlobalAnonThrottle returns a fixed key for anonymous requests, None for authenticated."""
+
+    def test_returns_fixed_key_for_anonymous_request(self, anonymous_request):
+        """Anonymous requests get a fixed global cache key."""
+        throttle = GlobalAnonThrottle()
+        key = throttle.get_cache_key(anonymous_request, view=None)
+        assert key is not None
+        assert "global_anon" in key
+        assert "global" in key
+
+    def test_returns_none_for_authenticated_request(self, authenticated_request):
+        """Authenticated requests are skipped (returns None)."""
+        throttle = GlobalAnonThrottle()
+        key = throttle.get_cache_key(authenticated_request, view=None)
+        assert key is None
+
+    def test_returns_none_when_user_is_authenticated_object(self, factory):
+        """Authenticated user object causes throttle to be skipped."""
+        request = factory.get("/api/v1/test/")
+        user = MagicMock()
+        user.is_authenticated = True
+        request.user = user
+        throttle = GlobalAnonThrottle()
+        key = throttle.get_cache_key(request, view=None)
+        assert key is None
+
+
+class TestGlobalAuthenticatedThrottleCacheKey:
+    """GlobalAuthenticatedThrottle returns a fixed key for authenticated requests, None for anonymous."""
+
+    def test_returns_fixed_key_for_authenticated_request(self, authenticated_request):
+        """Authenticated requests get a fixed global cache key."""
+        throttle = GlobalAuthenticatedThrottle()
+        key = throttle.get_cache_key(authenticated_request, view=None)
+        assert key is not None
+        assert "global_authenticated" in key
+        assert "global" in key
+
+    def test_returns_none_for_anonymous_request(self, anonymous_request):
+        """Anonymous requests are skipped (returns None)."""
+        throttle = GlobalAuthenticatedThrottle()
+        key = throttle.get_cache_key(anonymous_request, view=None)
+        assert key is None
+
+    def test_returns_none_when_user_not_authenticated(self, factory):
+        """User with is_authenticated=False causes throttle to be skipped."""
+        request = factory.get("/api/v1/test/")
+        user = MagicMock()
+        user.is_authenticated = False
+        request.user = user
+        throttle = GlobalAuthenticatedThrottle()
+        key = throttle.get_cache_key(request, view=None)
+        assert key is None
+
+
+class TestGlobalTaskThrottleCacheKey:
+    """GlobalTaskThrottle always returns a fixed key regardless of auth status."""
+
+    def test_returns_fixed_key_for_anonymous_request(self, anonymous_request):
+        """Anonymous requests get a fixed global cache key."""
+        throttle = GlobalTaskThrottle()
+        key = throttle.get_cache_key(anonymous_request, view=None)
+        assert key is not None
+        assert "global_task" in key
+        assert "global" in key
+
+    def test_returns_fixed_key_for_authenticated_request(self, authenticated_request):
+        """Authenticated requests also get a fixed global cache key."""
+        throttle = GlobalTaskThrottle()
+        key = throttle.get_cache_key(authenticated_request, view=None)
+        assert key is not None
+        assert "global_task" in key
+        assert "global" in key
+
+    def test_key_is_same_for_any_request(
+        self, anonymous_request, authenticated_request
+    ):
+        """The cache key is identical regardless of authentication status."""
+        throttle = GlobalTaskThrottle()
+        anon_key = throttle.get_cache_key(anonymous_request, view=None)
+        auth_key = throttle.get_cache_key(authenticated_request, view=None)
+        assert anon_key == auth_key
+
+
+class TestFailOpenBehavior:
+    """Throttle classes catch Redis ConnectionError and TimeoutError, returning True."""
+
+    @pytest.mark.django_db
+    def test_anon_throttle_allows_request_on_connection_error(self, anonymous_request):
+        """GlobalAnonThrottle returns True when Redis raises ConnectionError."""
+        throttle = GlobalAnonThrottle()
+        with patch.object(throttle, "cache", new_callable=MagicMock) as mock_cache:
+            mock_cache.get.side_effect = ConnectionError("Redis unavailable")
+            result = throttle.allow_request(anonymous_request, view=None)
+        assert result is True
+
+    @pytest.mark.django_db
+    def test_anon_throttle_allows_request_on_timeout_error(self, anonymous_request):
+        """GlobalAnonThrottle returns True when Redis raises TimeoutError."""
+        throttle = GlobalAnonThrottle()
+        with patch.object(throttle, "cache", new_callable=MagicMock) as mock_cache:
+            mock_cache.get.side_effect = TimeoutError("Redis timeout")
+            result = throttle.allow_request(anonymous_request, view=None)
+        assert result is True
+
+    @pytest.mark.django_db
+    def test_authenticated_throttle_allows_request_on_connection_error(
+        self, authenticated_request
+    ):
+        """GlobalAuthenticatedThrottle returns True when Redis raises ConnectionError."""
+        throttle = GlobalAuthenticatedThrottle()
+        with patch.object(throttle, "cache", new_callable=MagicMock) as mock_cache:
+            mock_cache.get.side_effect = ConnectionError("Redis unavailable")
+            result = throttle.allow_request(authenticated_request, view=None)
+        assert result is True
+
+    @pytest.mark.django_db
+    def test_authenticated_throttle_allows_request_on_timeout_error(
+        self, authenticated_request
+    ):
+        """GlobalAuthenticatedThrottle returns True when Redis raises TimeoutError."""
+        throttle = GlobalAuthenticatedThrottle()
+        with patch.object(throttle, "cache", new_callable=MagicMock) as mock_cache:
+            mock_cache.get.side_effect = TimeoutError("Redis timeout")
+            result = throttle.allow_request(authenticated_request, view=None)
+        assert result is True
+
+    @pytest.mark.django_db
+    def test_task_throttle_allows_request_on_connection_error(self, anonymous_request):
+        """GlobalTaskThrottle returns True when Redis raises ConnectionError."""
+        throttle = GlobalTaskThrottle()
+        with patch.object(throttle, "cache", new_callable=MagicMock) as mock_cache:
+            mock_cache.get.side_effect = ConnectionError("Redis unavailable")
+            result = throttle.allow_request(anonymous_request, view=None)
+        assert result is True
+
+    @pytest.mark.django_db
+    def test_task_throttle_allows_request_on_timeout_error(self, anonymous_request):
+        """GlobalTaskThrottle returns True when Redis raises TimeoutError."""
+        throttle = GlobalTaskThrottle()
+        with patch.object(throttle, "cache", new_callable=MagicMock) as mock_cache:
+            mock_cache.get.side_effect = TimeoutError("Redis timeout")
+            result = throttle.allow_request(anonymous_request, view=None)
+        assert result is True
+
+
+class TestThrottleScopes:
+    """Throttle classes use the correct scope names."""
+
+    def test_anon_throttle_scope(self):
+        """GlobalAnonThrottle uses 'global_anon' scope."""
+        throttle = GlobalAnonThrottle()
+        assert throttle.scope == "global_anon"
+
+    def test_authenticated_throttle_scope(self):
+        """GlobalAuthenticatedThrottle uses 'global_authenticated' scope."""
+        throttle = GlobalAuthenticatedThrottle()
+        assert throttle.scope == "global_authenticated"
+
+    def test_task_throttle_scope(self):
+        """GlobalTaskThrottle uses 'global_task' scope."""
+        throttle = GlobalTaskThrottle()
+        assert throttle.scope == "global_task"

--- a/src/smplfrm/smplfrm/tests/throttles/test_throttle_integration.py
+++ b/src/smplfrm/smplfrm/tests/throttles/test_throttle_integration.py
@@ -1,0 +1,280 @@
+"""
+Integration tests for API rate limiting through the DRF throttle pipeline.
+
+Tests verify end-to-end throttle behavior including HTTP status codes,
+response headers, response body format, bucket independence, and rate
+window recovery.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APIClient
+
+# Low throttle rates for testing — keeps tests fast and deterministic.
+TEST_THROTTLE_RATES = {
+    "global_anon": "3/minute",
+    "global_authenticated": "5/minute",
+    "global_task": "2/minute",
+}
+
+TEST_REST_FRAMEWORK = {
+    "DEFAULT_THROTTLE_CLASSES": [
+        "smplfrm.throttles.GlobalAnonThrottle",
+        "smplfrm.throttles.GlobalAuthenticatedThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": TEST_THROTTLE_RATES,
+}
+
+
+@pytest.fixture(autouse=True)
+def clear_throttle_cache():
+    """Clear the cache before and after each test to reset throttle counters."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def api_client():
+    """Unauthenticated DRF API client."""
+    return APIClient()
+
+
+@pytest.fixture
+def auth_user(db):
+    """Create a test user for authenticated requests."""
+    return User.objects.create_user(
+        username="throttle_test_user",
+        password="testpass123",
+    )
+
+
+@pytest.fixture
+def auth_client(auth_user):
+    """Authenticated DRF API client."""
+    client = APIClient()
+    client.force_authenticate(user=auth_user)
+    return client
+
+
+class TestAnonymousThrottling:
+    """Anonymous requests are throttled using the global anonymous bucket."""
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_requests_under_limit_succeed(self, api_client):
+        """Anonymous requests below the configured limit return HTTP 200."""
+        for _ in range(3):
+            response = api_client.get("/api/v1/configs")
+            assert response.status_code == 200
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_requests_over_limit_return_429(self, api_client):
+        """Anonymous requests exceeding the limit return HTTP 429."""
+        # Exhaust the limit (3 requests)
+        for _ in range(3):
+            api_client.get("/api/v1/configs")
+
+        # The 4th request should be throttled
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 429
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_429_response_has_retry_after_header(self, api_client):
+        """Throttled responses include a Retry-After header."""
+        for _ in range(3):
+            api_client.get("/api/v1/configs")
+
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 429
+        assert "Retry-After" in response
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_429_response_has_json_body_with_detail(self, api_client):
+        """Throttled responses include a JSON body with a 'detail' field."""
+        for _ in range(3):
+            api_client.get("/api/v1/configs")
+
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 429
+        data = response.json()
+        assert "detail" in data
+        assert isinstance(data["detail"], str)
+        assert len(data["detail"]) > 0
+
+
+class TestAuthenticatedThrottling:
+    """Authenticated requests are throttled using the global authenticated bucket."""
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_requests_under_limit_succeed(self, auth_client):
+        """Authenticated requests below the configured limit return HTTP 200."""
+        for _ in range(5):
+            response = auth_client.get("/api/v1/configs")
+            assert response.status_code == 200
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_requests_over_limit_return_429(self, auth_client):
+        """Authenticated requests exceeding the limit return HTTP 429."""
+        # Exhaust the limit (5 requests)
+        for _ in range(5):
+            auth_client.get("/api/v1/configs")
+
+        # The 6th request should be throttled
+        response = auth_client.get("/api/v1/configs")
+        assert response.status_code == 429
+
+
+class TestTaskEndpointThrottling:
+    """Task endpoint applies a stricter rate limit via GlobalTaskThrottle."""
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_task_endpoint_applies_stricter_limit(self, api_client):
+        """Task endpoint is throttled at 2/min (stricter than general 3/min)."""
+        # First 2 requests should succeed (task limit is 2/min)
+        for _ in range(2):
+            response = api_client.get("/api/v1/tasks")
+            assert response.status_code == 200
+
+        # 3rd request should be throttled by the task bucket
+        response = api_client.get("/api/v1/tasks")
+        assert response.status_code == 429
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_task_endpoint_counts_against_both_buckets(self, api_client):
+        """Requests to the task endpoint count against both task and general buckets."""
+        # Make 2 requests to the task endpoint (exhausts task bucket of 2)
+        for _ in range(2):
+            api_client.get("/api/v1/tasks")
+
+        # The general anon bucket (limit 3) should have 2 counted against it
+        # So we should have 1 remaining request on the general bucket
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 200
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_exhausting_task_bucket_does_not_block_other_endpoints(self, api_client):
+        """Exhausting the task-specific bucket does not block non-task endpoints."""
+        # Exhaust the task bucket (2 requests).
+        # These also count against the general anon bucket (2 of 3 used).
+        for _ in range(2):
+            api_client.get("/api/v1/tasks")
+
+        # Other endpoints should still work — the general anon bucket has
+        # capacity remaining (1 of 3 left).
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 200
+
+        # Meanwhile the task endpoint is throttled (task bucket exhausted)
+        response = api_client.get("/api/v1/tasks")
+        assert response.status_code == 429
+
+
+class TestBucketIndependence:
+    """Exhausting one bucket does not affect requests counted against another."""
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_exhausting_anon_bucket_does_not_block_authenticated(
+        self, api_client, auth_client
+    ):
+        """Exhausting the anonymous bucket does not block authenticated requests."""
+        # Exhaust anonymous bucket (3 requests)
+        for _ in range(3):
+            api_client.get("/api/v1/configs")
+
+        # Anonymous should be throttled
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 429
+
+        # Authenticated should still work
+        response = auth_client.get("/api/v1/configs")
+        assert response.status_code == 200
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_exhausting_authenticated_bucket_does_not_block_anonymous(
+        self, api_client, auth_client
+    ):
+        """Exhausting the authenticated bucket does not block anonymous requests."""
+        # Exhaust authenticated bucket (5 requests)
+        for _ in range(5):
+            auth_client.get("/api/v1/configs")
+
+        # Authenticated should be throttled
+        response = auth_client.get("/api/v1/configs")
+        assert response.status_code == 429
+
+        # Anonymous should still work
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 200
+
+
+class TestResponseFormat:
+    """Throttled responses have correct Content-Type and Retry-After format."""
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_429_response_content_type_is_json(self, api_client):
+        """Throttled responses have Content-Type: application/json."""
+        for _ in range(3):
+            api_client.get("/api/v1/configs")
+
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 429
+        assert "application/json" in response["Content-Type"]
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_retry_after_header_is_positive_integer(self, api_client):
+        """The Retry-After header value is a positive integer (whole seconds)."""
+        for _ in range(3):
+            api_client.get("/api/v1/configs")
+
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 429
+        retry_after = response["Retry-After"]
+        # Must be parseable as an integer
+        retry_value = int(retry_after)
+        # Must be positive (>= 1)
+        assert retry_value >= 1
+
+
+class TestRateWindowRecovery:
+    """After the rate window elapses, requests succeed again."""
+
+    @pytest.mark.django_db
+    @override_settings(REST_FRAMEWORK=TEST_REST_FRAMEWORK)
+    def test_requests_succeed_after_window_elapses(self, api_client):
+        """After the rate window expires, the throttle resets and allows requests."""
+        import time
+
+        # Exhaust the anonymous bucket
+        for _ in range(3):
+            api_client.get("/api/v1/configs")
+
+        # Confirm we're throttled
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 429
+
+        # Advance time past the 60-second window.
+        # DRF's SimpleRateThrottle uses time.time() to track request timestamps.
+        # We clear the cache to simulate TTL expiry (the in-memory/locmem cache
+        # doesn't actually expire entries based on mocked time).
+        cache.clear()
+
+        # After cache is cleared (simulating window expiry), requests succeed again
+        response = api_client.get("/api/v1/configs")
+        assert response.status_code == 200

--- a/src/smplfrm/smplfrm/tests/throttles/test_throttle_utils.py
+++ b/src/smplfrm/smplfrm/tests/throttles/test_throttle_utils.py
@@ -1,0 +1,221 @@
+"""
+Tests for throttle rate parsing utility.
+
+Verifies that parse_throttle_rate correctly validates rate strings from
+environment variables, returns valid rates unchanged, and falls back to
+defaults with a warning log when values are invalid or missing.
+"""
+
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+from smplfrm.throttle_utils import parse_throttle_rate
+
+
+class TestValidRates:
+    """Valid rate strings should be returned unchanged."""
+
+    @pytest.mark.parametrize(
+        "rate",
+        [
+            "60/minute",
+            "1/second",
+            "500/hour",
+            "10000/day",
+        ],
+        ids=["60-per-minute", "1-per-second", "500-per-hour", "10000-per-day"],
+    )
+    def test_valid_rate_returned_unchanged(self, rate):
+        """A well-formed rate string is returned as-is."""
+        with patch.dict(os.environ, {"TEST_RATE": rate}):
+            result = parse_throttle_rate("TEST_RATE", "60/minute")
+            assert result == rate
+
+    def test_valid_rate_with_large_number(self):
+        """Large positive integers are accepted."""
+        with patch.dict(os.environ, {"TEST_RATE": "999999/day"}):
+            result = parse_throttle_rate("TEST_RATE", "60/minute")
+            assert result == "999999/day"
+
+    def test_valid_rate_boundary_one(self):
+        """The minimum valid number (1) is accepted for all periods."""
+        for period in ("second", "minute", "hour", "day"):
+            rate = f"1/{period}"
+            with patch.dict(os.environ, {"TEST_RATE": rate}):
+                result = parse_throttle_rate("TEST_RATE", "60/minute")
+                assert result == rate
+
+
+class TestInvalidRates:
+    """Invalid rate strings should return the default and log a warning."""
+
+    @pytest.mark.parametrize(
+        "invalid_rate,description",
+        [
+            ("", "empty string"),
+            ("60minute", "missing slash"),
+            ("0/minute", "zero number"),
+            ("-1/minute", "negative number"),
+            ("60/weekly", "invalid period"),
+            ("abc/minute", "non-numeric prefix"),
+            ("60/minute/extra", "extra slashes"),
+        ],
+        ids=[
+            "empty-string",
+            "missing-slash",
+            "zero-number",
+            "negative-number",
+            "invalid-period",
+            "non-numeric-prefix",
+            "extra-slashes",
+        ],
+    )
+    def test_invalid_rate_returns_default(self, invalid_rate, description, caplog):
+        """Invalid rate format falls back to default and logs a warning."""
+        default = "120/minute"
+        with patch.dict(os.environ, {"TEST_RATE": invalid_rate}):
+            with caplog.at_level(logging.WARNING):
+                result = parse_throttle_rate("TEST_RATE", default)
+            assert result == default
+
+    @pytest.mark.parametrize(
+        "invalid_rate",
+        [
+            "",
+            "60minute",
+            "0/minute",
+            "-1/minute",
+            "60/weekly",
+            "abc/minute",
+            "60/minute/extra",
+        ],
+        ids=[
+            "empty-string",
+            "missing-slash",
+            "zero-number",
+            "negative-number",
+            "invalid-period",
+            "non-numeric-prefix",
+            "extra-slashes",
+        ],
+    )
+    def test_invalid_rate_logs_warning(self, invalid_rate, caplog):
+        """Invalid rate values produce a warning log message."""
+        with patch.dict(os.environ, {"TEST_RATE": invalid_rate}):
+            with caplog.at_level(logging.WARNING):
+                parse_throttle_rate("TEST_RATE", "60/minute")
+            assert len(caplog.records) > 0
+            assert caplog.records[0].levelno == logging.WARNING
+
+    def test_float_number_is_invalid(self, caplog):
+        """Decimal numbers are not valid (must be integer)."""
+        with patch.dict(os.environ, {"TEST_RATE": "3.5/minute"}):
+            with caplog.at_level(logging.WARNING):
+                result = parse_throttle_rate("TEST_RATE", "60/minute")
+            assert result == "60/minute"
+
+    def test_whitespace_only_is_invalid(self, caplog):
+        """Whitespace-only value is treated as invalid."""
+        with patch.dict(os.environ, {"TEST_RATE": "   "}):
+            with caplog.at_level(logging.WARNING):
+                result = parse_throttle_rate("TEST_RATE", "60/minute")
+            assert result == "60/minute"
+
+
+class TestMissingEnvVar:
+    """When the environment variable is not set, the default is returned."""
+
+    def test_missing_env_var_returns_default(self):
+        """Unset env var returns the provided default without logging."""
+        env_without_key = {k: v for k, v in os.environ.items() if k != "TEST_RATE"}
+        with patch.dict(os.environ, env_without_key, clear=True):
+            result = parse_throttle_rate("TEST_RATE", "60/minute")
+            assert result == "60/minute"
+
+    def test_missing_env_var_does_not_log_warning(self, caplog):
+        """Unset env var should not produce a warning (it's expected behavior)."""
+        env_without_key = {k: v for k, v in os.environ.items() if k != "TEST_RATE"}
+        with patch.dict(os.environ, env_without_key, clear=True):
+            with caplog.at_level(logging.WARNING):
+                parse_throttle_rate("TEST_RATE", "10/minute")
+            warning_records = [
+                r for r in caplog.records if r.levelno == logging.WARNING
+            ]
+            assert len(warning_records) == 0
+
+
+class TestSettingsRestFrameworkConfig:
+    """REST_FRAMEWORK settings dict contains correct throttle configuration."""
+
+    def test_rest_framework_setting_exists(self, settings):
+        """REST_FRAMEWORK dict is present in Django settings."""
+        assert hasattr(settings, "REST_FRAMEWORK")
+        assert isinstance(settings.REST_FRAMEWORK, dict)
+
+    def test_default_throttle_classes_configured(self, settings):
+        """DEFAULT_THROTTLE_CLASSES includes both global throttle classes."""
+        rf = settings.REST_FRAMEWORK
+        assert "DEFAULT_THROTTLE_CLASSES" in rf
+        expected_classes = [
+            "smplfrm.throttles.GlobalAnonThrottle",
+            "smplfrm.throttles.GlobalAuthenticatedThrottle",
+        ]
+        assert rf["DEFAULT_THROTTLE_CLASSES"] == expected_classes
+
+    def test_default_throttle_rates_contains_all_scopes(self, settings):
+        """DEFAULT_THROTTLE_RATES has entries for anon, authenticated, and task scopes."""
+        rf = settings.REST_FRAMEWORK
+        assert "DEFAULT_THROTTLE_RATES" in rf
+        rates = rf["DEFAULT_THROTTLE_RATES"]
+        assert "global_anon" in rates
+        assert "global_authenticated" in rates
+        assert "global_task" in rates
+
+    def test_default_throttle_rate_values(self, settings):
+        """Default throttle rates match expected values when no env vars are set."""
+        rates = settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]
+        assert rates["global_anon"] == "60/minute"
+        assert rates["global_authenticated"] == "120/minute"
+        assert rates["global_task"] == "10/minute"
+
+
+class TestSettingsThrottleEnvOverrides:
+    """Environment variables override default throttle rate values in settings."""
+
+    def test_anon_rate_env_override(self, monkeypatch):
+        """SMPL_FRM_THROTTLE_ANON_RATE env var overrides the anonymous rate."""
+        monkeypatch.setenv("SMPL_FRM_THROTTLE_ANON_RATE", "30/hour")
+        from smplfrm.throttle_utils import parse_throttle_rate
+
+        result = parse_throttle_rate("SMPL_FRM_THROTTLE_ANON_RATE", "60/minute")
+        assert result == "30/hour"
+
+    def test_user_rate_env_override(self, monkeypatch):
+        """SMPL_FRM_THROTTLE_USER_RATE env var overrides the authenticated rate."""
+        monkeypatch.setenv("SMPL_FRM_THROTTLE_USER_RATE", "200/minute")
+        from smplfrm.throttle_utils import parse_throttle_rate
+
+        result = parse_throttle_rate("SMPL_FRM_THROTTLE_USER_RATE", "120/minute")
+        assert result == "200/minute"
+
+    def test_task_rate_env_override(self, monkeypatch):
+        """SMPL_FRM_THROTTLE_TASK_RATE env var overrides the task creation rate."""
+        monkeypatch.setenv("SMPL_FRM_THROTTLE_TASK_RATE", "5/minute")
+        from smplfrm.throttle_utils import parse_throttle_rate
+
+        result = parse_throttle_rate("SMPL_FRM_THROTTLE_TASK_RATE", "10/minute")
+        assert result == "5/minute"
+
+    def test_invalid_env_override_falls_back_to_default(self, monkeypatch, caplog):
+        """Invalid env var value falls back to default rate."""
+        monkeypatch.setenv("SMPL_FRM_THROTTLE_ANON_RATE", "invalid")
+        from smplfrm.throttle_utils import parse_throttle_rate
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = parse_throttle_rate("SMPL_FRM_THROTTLE_ANON_RATE", "60/minute")
+        assert result == "60/minute"

--- a/src/smplfrm/smplfrm/throttle_utils.py
+++ b/src/smplfrm/smplfrm/throttle_utils.py
@@ -1,0 +1,66 @@
+"""Utility functions for throttle rate configuration."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+VALID_PERIODS = {"second", "minute", "hour", "day"}
+
+
+def parse_throttle_rate(env_var: str, default: str) -> str:
+    """Read a throttle rate from an environment variable and validate its format.
+
+    Returns the environment variable value if it matches the format
+    ``{positive_integer}/{period}`` where period is one of second, minute,
+    hour, or day. If the variable is not set, returns the default silently.
+    If the variable is set but invalid, returns the default and logs a warning.
+    """
+    value = os.getenv(env_var)
+
+    if value is None:
+        return default
+
+    parts = value.strip().split("/")
+
+    if len(parts) != 2:
+        logger.warning(
+            "Invalid throttle rate '%s' for %s, using default '%s'",
+            value,
+            env_var,
+            default,
+        )
+        return default
+
+    number_str, period = parts
+
+    try:
+        number = int(number_str)
+    except ValueError:
+        logger.warning(
+            "Invalid throttle rate '%s' for %s, using default '%s'",
+            value,
+            env_var,
+            default,
+        )
+        return default
+
+    if number < 1:
+        logger.warning(
+            "Invalid throttle rate '%s' for %s, using default '%s'",
+            value,
+            env_var,
+            default,
+        )
+        return default
+
+    if period not in VALID_PERIODS:
+        logger.warning(
+            "Invalid throttle rate '%s' for %s, using default '%s'",
+            value,
+            env_var,
+            default,
+        )
+        return default
+
+    return value

--- a/src/smplfrm/smplfrm/throttles.py
+++ b/src/smplfrm/smplfrm/throttles.py
@@ -1,0 +1,104 @@
+"""Custom throttle classes for global-bucket rate limiting.
+
+Provides three throttle classes that use a shared global counter (rather than
+per-IP) to protect the system from aggregate request flooding:
+
+- GlobalAnonThrottle: limits anonymous (unauthenticated) requests
+- GlobalAuthenticatedThrottle: limits authenticated requests
+- GlobalTaskThrottle: limits task creation requests regardless of auth status
+
+All classes fail open when Redis is unavailable, logging a warning instead of
+blocking requests.
+"""
+
+import logging
+
+from rest_framework.throttling import SimpleRateThrottle
+
+logger = logging.getLogger(__name__)
+
+# Default rates used when REST_FRAMEWORK settings are not yet configured.
+_DEFAULT_RATES = {
+    "global_anon": "60/minute",
+    "global_authenticated": "120/minute",
+    "global_task": "10/minute",
+}
+
+
+class _FailOpenThrottleMixin:
+    """Mixin that provides fail-open behavior and default rate fallback.
+
+    Catches ConnectionError and TimeoutError from Redis during throttle checks
+    and allows the request through, logging a warning. Also provides a default
+    rate when the scope is not configured in REST_FRAMEWORK settings.
+    """
+
+    def get_rate(self):
+        """Return the rate from current settings, falling back to built-in defaults.
+
+        Reads directly from api_settings to respect override_settings in tests,
+        since SimpleRateThrottle.THROTTLE_RATES is a class attribute set once
+        at import time and is not updated when settings change.
+        """
+        from rest_framework.settings import api_settings
+
+        try:
+            rates = api_settings.DEFAULT_THROTTLE_RATES or {}
+            return rates[self.scope]
+        except (KeyError, TypeError):
+            return _DEFAULT_RATES.get(self.scope)
+
+    def allow_request(self, request, view):
+        try:
+            return super().allow_request(request, view)
+        except (ConnectionError, TimeoutError):
+            logger.warning(
+                "Redis unavailable during %s throttle check, allowing request",
+                self.scope,
+            )
+            return True
+
+
+class GlobalAnonThrottle(_FailOpenThrottleMixin, SimpleRateThrottle):
+    """Global bucket throttle for anonymous requests.
+
+    Returns a fixed cache key for anonymous requests so all unauthenticated
+    clients share a single rate limit counter. Authenticated requests are
+    skipped (returns None) since they are handled by GlobalAuthenticatedThrottle.
+    """
+
+    scope = "global_anon"
+
+    def get_cache_key(self, request, view):
+        if request.user and request.user.is_authenticated:
+            return None
+        return self.cache_format % {"scope": self.scope, "ident": "global"}
+
+
+class GlobalAuthenticatedThrottle(_FailOpenThrottleMixin, SimpleRateThrottle):
+    """Global bucket throttle for authenticated requests.
+
+    Returns a fixed cache key for authenticated requests so all authenticated
+    clients share a single rate limit counter. Anonymous requests are skipped
+    (returns None) since they are handled by GlobalAnonThrottle.
+    """
+
+    scope = "global_authenticated"
+
+    def get_cache_key(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return None
+        return self.cache_format % {"scope": self.scope, "ident": "global"}
+
+
+class GlobalTaskThrottle(_FailOpenThrottleMixin, SimpleRateThrottle):
+    """Global bucket throttle for task creation endpoint.
+
+    Always returns a fixed cache key regardless of authentication status,
+    applying a shared rate limit to all task creation requests.
+    """
+
+    scope = "global_task"
+
+    def get_cache_key(self, request, view):
+        return self.cache_format % {"scope": self.scope, "ident": "global"}

--- a/src/smplfrm/smplfrm/views/api/v1/tasks.py
+++ b/src/smplfrm/smplfrm/views/api/v1/tasks.py
@@ -8,6 +8,11 @@ from rest_framework.response import Response
 
 from smplfrm.models import Task
 from smplfrm.services.task_service import TaskService
+from smplfrm.throttles import (
+    GlobalAnonThrottle,
+    GlobalAuthenticatedThrottle,
+    GlobalTaskThrottle,
+)
 from smplfrm.views.serializers.v1.task_serializer import TaskSerializer
 
 logger = logging.getLogger(__name__)
@@ -29,6 +34,11 @@ class TaskViewSet(viewsets.ModelViewSet):
     serializer_class = TaskSerializer
     pagination_class = TaskPagination
     lookup_field = "external_id"
+    throttle_classes = [
+        GlobalAnonThrottle,
+        GlobalAuthenticatedThrottle,
+        GlobalTaskThrottle,
+    ]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
## Summary

Implements API rate limiting using DRF's built-in throttle framework with custom subclasses that use a global bucket (fixed cache key) instead of per-IP tracking.

## Changes

- **`smplfrm/throttles.py`** — Three throttle classes: `GlobalAnonThrottle` (60/min), `GlobalAuthenticatedThrottle` (120/min), `GlobalTaskThrottle` (10/min). All fail open on Redis errors.
- **`smplfrm/throttle_utils.py`** — `parse_throttle_rate()` utility for env var validation with fallback to defaults.
- **`smplfrm/settings.py`** — `REST_FRAMEWORK` dict with throttle classes and rates configured via env vars.
- **`views/api/v1/tasks.py`** — TaskViewSet applies all three throttles (stricter 10/min task limit).
- **`scripts/utils/rate_limit_tester.py`** — Reusable perf testing classes for manual verification.
- **`scripts/verify_rate_limits.py`** — CLI script to verify limits against a running instance.
- **`docs/Environment-Variables.md`** — New Security section documenting throttle env vars.
- **`docker/compose/config.env`** — Commented-out throttle env vars for discoverability.

## Testing

- 64 new throttle tests (unit + integration) — all passing
- Full project suite: 406 tests passing
- Manual verification script: `python scripts/verify_rate_limits.py`

## Configuration

| Env Var | Default | Description |
|---------|---------|-------------|
| `SMPL_FRM_THROTTLE_ANON_RATE` | `60/minute` | Global anonymous rate limit |
| `SMPL_FRM_THROTTLE_USER_RATE` | `120/minute` | Global authenticated rate limit |
| `SMPL_FRM_THROTTLE_TASK_RATE` | `10/minute` | Task endpoint rate limit |

Closes #191