### PR TITLE
fix(api): remove file_path from Image API responses

### DIFF
--- a/src/smplfrm/smplfrm/tests/views/test_image_api.py
+++ b/src/smplfrm/smplfrm/tests/views/test_image_api.py
@@ -20,6 +20,33 @@ class TestImageAPI(TestCase):
         self.assertIn("view_count", response.data)
         self.assertEqual(response.data["view_count"], 0)
 
+    def test_get_image_does_not_expose_file_path(self):
+        """Test that image API response does not contain file_path."""
+        response = self.client.get(f"/api/v1/images/{self.image.external_id}")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("file_path", response.data)
+
+    def test_list_images_does_not_expose_file_path(self):
+        """Test that image list API response does not contain file_path."""
+        response = self.client.get("/api/v1/images")
+        self.assertEqual(response.status_code, 200)
+        for image in response.json():
+            self.assertNotIn("file_path", image)
+
+    def test_get_image_returns_expected_fields_only(self):
+        """Test that image API response contains exactly the expected fields."""
+        response = self.client.get(f"/api/v1/images/{self.image.external_id}")
+        self.assertEqual(response.status_code, 200)
+        expected_fields = {
+            "id",
+            "name",
+            "file_name",
+            "created",
+            "updated",
+            "view_count",
+        }
+        self.assertEqual(set(response.data.keys()), expected_fields)
+
 
 from smplfrm.services import ImageService, LibraryService
 

--- a/src/smplfrm/smplfrm/views/serializers/v1/image_serializer.py
+++ b/src/smplfrm/smplfrm/views/serializers/v1/image_serializer.py
@@ -12,7 +12,6 @@ class ImageSerializer(serializers.HyperlinkedModelSerializer):
         fields = [
             "id",
             "name",
-            "file_path",
             "file_name",
             "created",
             "updated",


### PR DESCRIPTION
## Summary

Removes `file_path` from `ImageSerializer.Meta.fields` to fix an information disclosure vulnerability that exposed full server filesystem paths (e.g., `/app/library/2024/11/photo.jpg`) in all Image API responses.

## Changes

- Removed `"file_path"` from the serializer fields list in `image_serializer.py`
- API now returns only: `id`, `name`, `file_name`, `created`, `updated`, `view_count`

## Verification

- Full test suite passes (411 tests)
- Confirmed `file_path` was not used anywhere in the frontend UI
- No breaking changes — the field was dead weight in API responses

Closes #190